### PR TITLE
docs(lambda): rename regulator → reducer in TENX_APP descriptions

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -44,7 +44,7 @@ aws logs put-subscription-filter \
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `TENX_API_KEY` | Yes | Log10x API key |
-| `TENX_APP` | No | `@apps/edge/reporter`, `@apps/edge/regulator`, or `@apps/edge/optimizer` (default: reporter) |
+| `TENX_APP` | No | `@apps/reporter` or `@apps/reducer` (default: reporter) |
 | `TENX_EXTRA_ARGS` | No | Additional CLI arguments for the 10x engine |
 
 Output destination is controlled by the 10x pipeline config via Fluent Bit output plugins. Set env vars for your destination:

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -7,7 +7,7 @@ configuration (e.g., Fluent Bit output to Datadog, Splunk, Elasticsearch).
 
 Environment variables:
     TENX_API_KEY    - Log10x API key for licensing and metrics
-    TENX_APP        - 10x app to run: @apps/edge/reporter, @apps/edge/regulator, or @apps/edge/optimizer
+    TENX_APP        - 10x app to run: @apps/reporter or @apps/reducer (default: reporter)
     TENX_EXTRA_ARGS - Optional extra CLI arguments for the 10x engine (space-separated)
 
 Output destination is controlled by the 10x pipeline config, not this handler.


### PR DESCRIPTION
## Summary
- `lambda/handler.py` docstring: regulator → reducer in TENX_APP description
- `lambda/README.md` table: regulator → reducer in TENX_APP description

Reflects the apps/edge/regulator → apps/reducer rename in log-10x/modules#21 + log-10x/config#20. No runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)