### PR TITLE
build(compiler): prod compiler-10x image, built alongside edge/pipeline/quarkus/lambda

### DIFF
--- a/.github/workflows/publish_10x_all_containers.yaml
+++ b/.github/workflows/publish_10x_all_containers.yaml
@@ -36,6 +36,11 @@ on:
         type: boolean
         description: Publish Lambda
         default: true
+      publish_compiler:
+        required: true
+        type: boolean
+        description: Publish Compiler
+        default: true
 jobs:
   prepare:
     name: Resolve version
@@ -63,6 +68,16 @@ jobs:
     needs: prepare
     name: Pipeline
     uses: ./.github/workflows/publish_10x_pipeline.yaml
+    with:
+      release_version: ${{ needs.prepare.outputs.release_version }}
+      docker_hub: ${{ inputs.docker_hub }}
+    secrets: inherit
+
+  Compiler:
+    if: ${{ inputs.publish_compiler }}
+    needs: prepare
+    name: Compiler
+    uses: ./.github/workflows/publish_10x_compiler.yaml
     with:
       release_version: ${{ needs.prepare.outputs.release_version }}
       docker_hub: ${{ inputs.docker_hub }}

--- a/.github/workflows/publish_10x_all_containers.yaml
+++ b/.github/workflows/publish_10x_all_containers.yaml
@@ -73,9 +73,14 @@ jobs:
       docker_hub: ${{ inputs.docker_hub }}
     secrets: inherit
 
+  # Compiler must run AFTER Pipeline — its Dockerfile is
+  # `FROM log10x/pipeline-10x:${ENGINE_VERSION}` and would fail if the
+  # pipeline tag for this version isn't published yet.
   Compiler:
     if: ${{ inputs.publish_compiler }}
-    needs: prepare
+    needs:
+      - prepare
+      - Pipeline
     name: Compiler
     uses: ./.github/workflows/publish_10x_compiler.yaml
     with:

--- a/.github/workflows/publish_10x_compiler.yaml
+++ b/.github/workflows/publish_10x_compiler.yaml
@@ -86,9 +86,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
-
       - name: Login to GHCR
         if: ${{ inputs.docker_hub == 'GHCR' || inputs.docker_hub == 'All' }}
         uses: docker/login-action@v4
@@ -125,8 +122,7 @@ jobs:
           push: true
           provenance: false
           build-args: |
-            VERSION=${{inputs.release_version}}
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
+            ENGINE_VERSION=${{inputs.release_version}}
           tags: ${{ steps.docker-meta.outputs.tags }}
 
   publish_aarch64:
@@ -140,9 +136,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: main
-
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       - name: Login to GHCR
         if: ${{ inputs.docker_hub == 'GHCR' || inputs.docker_hub == 'All' }}
@@ -180,8 +173,7 @@ jobs:
           push: true
           provenance: false
           build-args: |
-            VERSION=${{inputs.release_version}}
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
+            ENGINE_VERSION=${{inputs.release_version}}
           tags: ${{ steps.docker-meta.outputs.tags }}
 
   publish_version_manifest:

--- a/.github/workflows/publish_10x_compiler.yaml
+++ b/.github/workflows/publish_10x_compiler.yaml
@@ -1,0 +1,215 @@
+name: Publish 10x Compiler container
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        required: true
+        description: '10x version to install'
+        type: string
+      docker_hub:
+        required: true
+        description: 'Which docker hub to publish to'
+        type: choice
+        options:
+          - All
+          - GHCR
+          - DockerHub
+
+  workflow_call:
+    inputs:
+      release_version:
+        required: true
+        type: string
+      docker_hub:
+        required: true
+        type: string
+
+jobs:
+  prepare:
+    name: Checks parameters and sets vars
+    runs-on: ubuntu-latest
+    outputs:
+      image_name: ${{ steps.vars.outputs.image_name }}
+      version_tag: ${{ steps.vars.outputs.version_tag }}
+      docker_file: ${{ steps.vars.outputs.docker_file }}
+      docker_context: ${{ steps.vars.outputs.docker_context }}
+      docker_repo: ${{ steps.vars.outputs.docker_repo }}
+      dockerhub_repo: ${{ steps.vars.outputs.dockerhub_repo }}
+      docker_images: ${{ steps.vars.outputs.docker_images }}
+    steps:
+      - name: Check parameters
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const validHubs = ["GHCR", "DockerHub", "All"];
+            if (!validHubs.includes("${{ inputs.docker_hub }}")) {
+              core.setFailed("docker_hub must be one of: GHCR, DockerHub, All")
+            }
+
+      - name: Prepare variables
+        id: vars
+        run: |
+          echo "image_name=compiler-10x" >> "$GITHUB_OUTPUT"
+          echo "docker_file=./main/compiler/Dockerfile" >> "$GITHUB_OUTPUT"
+          echo "docker_context=./main/compiler" >> "$GITHUB_OUTPUT"
+          echo "version_tag=${{inputs.release_version}}" >> "$GITHUB_OUTPUT"
+          echo "docker_repo=${{ vars.GHCR_REPO_NAME }}" >> "$GITHUB_OUTPUT"
+          echo "dockerhub_repo=docker.io/${{ vars.DOCKERHUB_REPO_NAME }}" >> "$GITHUB_OUTPUT"
+
+          IMAGES=""
+          if [ "${{ inputs.docker_hub }}" == "GHCR" ] || [ "${{ inputs.docker_hub }}" == "All" ]; then
+            IMAGES="${{ vars.GHCR_REPO_NAME }}/compiler-10x"
+          fi
+          if [ "${{ inputs.docker_hub }}" == "DockerHub" ] || [ "${{ inputs.docker_hub }}" == "All" ]; then
+            if [ -n "$IMAGES" ]; then
+              IMAGES=$(printf '%s\n%s' "$IMAGES" "docker.io/${{ vars.DOCKERHUB_REPO_NAME }}/compiler-10x")
+            else
+              IMAGES="docker.io/${{ vars.DOCKERHUB_REPO_NAME }}/compiler-10x"
+            fi
+          fi
+          {
+            echo 'docker_images<<EOF'
+            echo "$IMAGES"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+  publish_x86:
+    name: "Build x86 Compiler ${{needs.prepare.outputs.version_tag}}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: prepare
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          path: main
+
+      - name: Load embedded limited license JWT
+        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
+
+      - name: Login to GHCR
+        if: ${{ inputs.docker_hub == 'GHCR' || inputs.docker_hub == 'All' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: ${{ inputs.docker_hub == 'DockerHub' || inputs.docker_hub == 'All' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker-meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{needs.prepare.outputs.docker_images}}
+          tags: |
+            type=raw,value=${{needs.prepare.outputs.version_tag}}-amd64
+            type=raw,value=latest-amd64,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Publish container
+        uses: docker/build-push-action@v7
+        with:
+          file: ${{needs.prepare.outputs.docker_file}}
+          context: ${{needs.prepare.outputs.docker_context}}
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          build-args: |
+            VERSION=${{inputs.release_version}}
+            LICENSE_JWT=${{ env.LICENSE_JWT }}
+          tags: ${{ steps.docker-meta.outputs.tags }}
+
+  publish_aarch64:
+    name: "Build aarch64 Compiler ${{needs.prepare.outputs.version_tag}}"
+    runs-on: linux-arm64-2core
+    timeout-minutes: 15
+    needs: prepare
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          path: main
+
+      - name: Load embedded limited license JWT
+        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
+
+      - name: Login to GHCR
+        if: ${{ inputs.docker_hub == 'GHCR' || inputs.docker_hub == 'All' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: ${{ inputs.docker_hub == 'DockerHub' || inputs.docker_hub == 'All' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker-meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{needs.prepare.outputs.docker_images}}
+          tags: |
+            type=raw,value=${{needs.prepare.outputs.version_tag}}-aarch64
+            type=raw,value=latest-aarch64,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Publish container
+        uses: docker/build-push-action@v7
+        with:
+          file: ${{needs.prepare.outputs.docker_file}}
+          context: ${{needs.prepare.outputs.docker_context}}
+          platforms: linux/arm64
+          push: true
+          provenance: false
+          build-args: |
+            VERSION=${{inputs.release_version}}
+            LICENSE_JWT=${{ env.LICENSE_JWT }}
+          tags: ${{ steps.docker-meta.outputs.tags }}
+
+  publish_version_manifest:
+    name: Publish multiarch manifest for ${{needs.prepare.outputs.version_tag}}
+    needs:
+      - prepare
+      - publish_x86
+      - publish_aarch64
+    uses: ./.github/workflows/update_multiarch_manifest.yaml
+    with:
+      version_tag: ${{needs.prepare.outputs.version_tag}}
+      docker_hub: ${{ inputs.docker_hub }}
+      docker_repo: ${{ needs.prepare.outputs.docker_repo }}
+      image_name: ${{ needs.prepare.outputs.image_name }}
+      dockerhub_repo: ${{ needs.prepare.outputs.dockerhub_repo }}
+    secrets: inherit
+
+  publish_latest_manifest:
+    name: Publish multiarch manifest for latest
+    needs:
+      - prepare
+      - publish_x86
+      - publish_aarch64
+    uses: ./.github/workflows/update_multiarch_manifest.yaml
+    with:
+      version_tag: latest
+      docker_hub: ${{ inputs.docker_hub }}
+      docker_repo: ${{ needs.prepare.outputs.docker_repo }}
+      image_name: ${{ needs.prepare.outputs.image_name }}
+      dockerhub_repo: ${{ needs.prepare.outputs.dockerhub_repo }}
+    secrets: inherit

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,0 +1,115 @@
+# Copyright (c) 2025-2026 Log10x, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi8/ubi:8.10 AS tenx-builder
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG VERSION
+ARG FLAVOR="cloud"
+
+# Install curl, needed for 10x install script
+#
+RUN dnf install -y curl
+
+# Install 10x
+#
+RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup
+
+FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi8/ubi-minimal:8.10
+
+# OCI Image Labels
+LABEL org.opencontainers.image.title="Log10x Compiler"
+LABEL org.opencontainers.image.description="Log10x AOT symbol compiler with the source-fetch toolchain (git, docker CLI, helm) bundled"
+LABEL org.opencontainers.image.vendor="Log10x, Inc."
+LABEL org.opencontainers.image.licenses="LicenseRef-Log10x-Proprietary"
+LABEL org.opencontainers.image.documentation="https://doc.log10x.com"
+LABEL org.opencontainers.image.source="https://github.com/log-10x/docker-images"
+LABEL com.log10x.license.required="true"
+LABEL com.log10x.license.url="https://log10x.com/pricing"
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG FLAVOR="cloud"
+ARG LICENSE_JWT
+
+# Pinned versions of the bundled source-fetch CLIs (bump as needed).
+ARG DOCKER_CLI_VERSION=27.3.1
+ARG HELM_VERSION=v3.16.4
+
+# Install binutils (strings) + file (executable scanner), needed for 10x 'compile'
+# Install shadow-utils, needed for useradd
+#
+RUN microdnf install -y binutils file shadow-utils
+
+# Install python3, needed for 10x 'compile'
+#
+RUN microdnf install -y python39 python39-pip && \
+    python3 -m pip install --no-cache-dir --upgrade pip setuptools urllib3 && \
+    rpm -e --nodeps python39-pip python39-pip-wheel \
+                    python39-setuptools python39-setuptools-wheel 2>/dev/null; true
+
+# Source-fetch toolchain for the compiler 'pull' stage. These are intentionally
+# NOT in the lean pipeline-10x image; the compiler image is the one that bundles
+# them so the pipeline image stays small:
+#   git        - pull source from git repos
+#   docker CLI - docker-image pull/scan (client only; needs a mounted
+#                /var/run/docker.sock or a remote DOCKER_HOST at runtime)
+#   helm       - pull/render Helm charts
+# fluent-bit is intentionally omitted: it is a run-pipeline forwarder, unused by 'compile'.
+#
+RUN microdnf install -y git tar gzip && \
+    case "${TARGETPLATFORM:-linux/amd64}" in \
+      "linux/arm64") DOCKER_ARCH=aarch64 ; HELM_ARCH=arm64 ;; \
+      *)             DOCKER_ARCH=x86_64  ; HELM_ARCH=amd64 ;; \
+    esac && \
+    curl -fsSL "https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_CLI_VERSION}.tgz" \
+      | tar -xz -C /tmp docker/docker && \
+    install -m 0755 /tmp/docker/docker /usr/local/bin/docker && \
+    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${HELM_ARCH}.tar.gz" \
+      | tar -xz -C /tmp && \
+    install -m 0755 /tmp/linux-${HELM_ARCH}/helm /usr/local/bin/helm && \
+    rm -rf /tmp/docker /tmp/linux-${HELM_ARCH}
+
+# Clean up the microdnf cache to reduce image size
+#
+RUN microdnf clean all
+
+# Make sure path for log file exists and is accessible to all users.
+# This allows changing TENX_LOG_APPENDER to tenxFileAppender if desired
+#
+RUN mkdir -p /var/log/tenx && chmod 777 /var/log/tenx
+
+# Manually setting up 10x environment variables
+#
+ENV TENX_HOME=/opt/tenx-${FLAVOR}
+ENV TENX_BIN=/opt/tenx-${FLAVOR}/bin/tenx-${FLAVOR}
+ENV TENX_MODULES=/opt/tenx-${FLAVOR}/lib/app/modules
+ENV TENX_CONFIG=/etc/tenx/config
+ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
+ENV TENX_LICENSE_KEY=${LICENSE_JWT}
+
+# Set 10x logger to console.
+#
+ENV TENX_LOG_APPENDER=tenxConsoleAppender
+
+# Copy 10x from builder
+#
+COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
+COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
+COPY --from=tenx-builder $TENX_HOME $TENX_HOME
+
+# Give permissions to the config
+#
+RUN chmod -R 777 $TENX_CONFIG
+
+# Create tenxuser user and run from their home directory
+RUN useradd -m -u 1000 tenxuser
+USER tenxuser
+WORKDIR /home/tenxuser
+
+ENTRYPOINT [ "sh", "-c", "exec $TENX_BIN \"${@}\"", "--" ]
+
+# Default to running the compiler
+#
+CMD [ "@apps/compiler" ]

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,64 +1,38 @@
 # Copyright (c) 2025-2026 Log10x, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi8/ubi:8.10 AS tenx-builder
+# The compiler image is a LITERAL EXTENSION of pipeline-10x: identical engine,
+# config, modules, symbols, baked license and tooling (incl. fluent-bit) — plus
+# the source-fetch toolchain (git, docker CLI, helm) the compile 'pull' stage
+# shells out to. It is built AFTER pipeline-10x (see `needs: Pipeline` in
+# publish_10x_all_containers.yaml) and pulls that exact tag as its base.
 
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-ARG VERSION
-ARG FLAVOR="cloud"
+ARG ENGINE_VERSION
+ARG ENGINE_IMAGE=log10x/pipeline-10x:${ENGINE_VERSION}
 
-# Install curl, needed for 10x install script
-#
-RUN dnf install -y curl
+FROM ${ENGINE_IMAGE}
 
-# Install 10x
-#
-RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup
-
-FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi8/ubi-minimal:8.10
-
-# OCI Image Labels
+# Override the inherited pipeline OCI labels
 LABEL org.opencontainers.image.title="Log10x Compiler"
-LABEL org.opencontainers.image.description="Log10x AOT symbol compiler with the source-fetch toolchain (git, docker CLI, helm) bundled"
-LABEL org.opencontainers.image.vendor="Log10x, Inc."
-LABEL org.opencontainers.image.licenses="LicenseRef-Log10x-Proprietary"
-LABEL org.opencontainers.image.documentation="https://doc.log10x.com"
+LABEL org.opencontainers.image.description="Log10x AOT symbol compiler: pipeline-10x plus the source-fetch toolchain (git, docker CLI, helm)"
 LABEL org.opencontainers.image.source="https://github.com/log-10x/docker-images"
-LABEL com.log10x.license.required="true"
-LABEL com.log10x.license.url="https://log10x.com/pricing"
 
 ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-ARG FLAVOR="cloud"
-ARG LICENSE_JWT
-
 # Pinned versions of the bundled source-fetch CLIs (bump as needed).
 ARG DOCKER_CLI_VERSION=27.3.1
 ARG HELM_VERSION=v3.16.4
 
-# Install binutils (strings) + file (executable scanner), needed for 10x 'compile'
-# Install shadow-utils, needed for useradd
-#
-RUN microdnf install -y binutils file shadow-utils
+USER root
 
-# Install python3, needed for 10x 'compile'
-#
-RUN microdnf install -y python39 python39-pip && \
-    python3 -m pip install --no-cache-dir --upgrade pip setuptools urllib3 && \
-    rpm -e --nodeps python39-pip python39-pip-wheel \
-                    python39-setuptools python39-setuptools-wheel 2>/dev/null; true
-
-# Source-fetch toolchain for the compiler 'pull' stage. These are intentionally
-# NOT in the lean pipeline-10x image; the compiler image is the one that bundles
-# them so the pipeline image stays small:
+# Source-fetch toolchain for the compile 'pull' stage:
 #   git        - pull source from git repos
 #   docker CLI - docker-image pull/scan (client only; needs a mounted
 #                /var/run/docker.sock or a remote DOCKER_HOST at runtime)
 #   helm       - pull/render Helm charts
-# fluent-bit is intentionally omitted: it is a run-pipeline forwarder, unused by 'compile'.
-#
-RUN microdnf install -y git tar gzip && \
+# Drop the inherited fluent-bit repo file first so this install doesn't try to
+# refresh it over the network (fluent-bit itself stays installed from the base).
+RUN rm -f /etc/yum.repos.d/fluent-bit.repo && \
+    microdnf install -y git tar gzip && \
     case "${TARGETPLATFORM:-linux/amd64}" in \
       "linux/arm64") DOCKER_ARCH=aarch64 ; HELM_ARCH=arm64 ;; \
       *)             DOCKER_ARCH=x86_64  ; HELM_ARCH=amd64 ;; \
@@ -69,47 +43,11 @@ RUN microdnf install -y git tar gzip && \
     curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${HELM_ARCH}.tar.gz" \
       | tar -xz -C /tmp && \
     install -m 0755 /tmp/linux-${HELM_ARCH}/helm /usr/local/bin/helm && \
-    rm -rf /tmp/docker /tmp/linux-${HELM_ARCH}
+    rm -rf /tmp/docker /tmp/linux-${HELM_ARCH} && \
+    microdnf clean all
 
-# Clean up the microdnf cache to reduce image size
-#
-RUN microdnf clean all
-
-# Make sure path for log file exists and is accessible to all users.
-# This allows changing TENX_LOG_APPENDER to tenxFileAppender if desired
-#
-RUN mkdir -p /var/log/tenx && chmod 777 /var/log/tenx
-
-# Manually setting up 10x environment variables
-#
-ENV TENX_HOME=/opt/tenx-${FLAVOR}
-ENV TENX_BIN=/opt/tenx-${FLAVOR}/bin/tenx-${FLAVOR}
-ENV TENX_MODULES=/opt/tenx-${FLAVOR}/lib/app/modules
-ENV TENX_CONFIG=/etc/tenx/config
-ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
-ENV TENX_LICENSE_KEY=${LICENSE_JWT}
-
-# Set 10x logger to console.
-#
-ENV TENX_LOG_APPENDER=tenxConsoleAppender
-
-# Copy 10x from builder
-#
-COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
-COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
-COPY --from=tenx-builder $TENX_HOME $TENX_HOME
-
-# Give permissions to the config
-#
-RUN chmod -R 777 $TENX_CONFIG
-
-# Create tenxuser user and run from their home directory
-RUN useradd -m -u 1000 tenxuser
 USER tenxuser
-WORKDIR /home/tenxuser
 
-ENTRYPOINT [ "sh", "-c", "exec $TENX_BIN \"${@}\"", "--" ]
-
-# Default to running the compiler
-#
+# Default to running the compiler. ENTRYPOINT, all TENX_* env, the baked
+# license and the tenxuser/workdir are inherited from pipeline-10x.
 CMD [ "@apps/compiler" ]


### PR DESCRIPTION
## What
The production `compiler-10x` image — a **literal extension of `pipeline-10x`**.

- **`compiler/Dockerfile`** — `FROM log10x/pipeline-10x:${ENGINE_VERSION}` + the source-fetch toolchain (`git`, `docker` CLI, `helm`). Everything else — engine, config, modules, symbols, fluent-bit, the baked license, env, entrypoint — is inherited. `CMD` defaults to `@apps/compiler`. Mirrors how `lambda-10x` extends `quarkus-10x`.
- **`publish_10x_compiler.yaml`** — reusable per-image workflow (x86 + aarch64 + multiarch manifest) publishing `compiler-10x` to GHCR/DockerHub. No LICENSE_JWT handling (inherited from the base).
- **`publish_10x_all_containers.yaml`** — added a `Compiler` job (`needs: Pipeline`, since it `FROM`s the pipeline tag) + a `publish_compiler` input, so it builds **alongside edge/pipeline/quarkus/lambda**.

## Why
The lean `pipeline-10x` lacks `git`/`docker`/`helm`, so the compiler's pull stage can't self-fetch. A literal superset bundles those without bloating pipeline, and guarantees the compiler base never drifts from pipeline.

## Validation
Tooling layer built on `ubi-minimal:8.10` (`git 2.43.7`, `docker 27.3.1`, `helm v3.16.4`). The extension Dockerfile builds against a v1.1.5 pipeline base and yields engine + all three tools + the inherited license. YAML validated.

## Note
The dev `compiler-10x-dev` (in `engine`, PR #54) stays **independent** (built from RPM artifacts) so it can be built separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)