### PR TITLE
build(compiler): daemonless docker-image pull via podman

### DIFF
--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -3,7 +3,7 @@
 
 # The compiler image is a LITERAL EXTENSION of pipeline-10x: identical engine,
 # config, modules, symbols, baked license and tooling (incl. fluent-bit) — plus
-# the source-fetch toolchain (git, docker CLI, helm) the compile 'pull' stage
+# the source-fetch toolchain (git, podman, helm) the compile 'pull' stage
 # shells out to. It is built AFTER pipeline-10x (see `needs: Pipeline` in
 # publish_10x_all_containers.yaml) and pulls that exact tag as its base.
 
@@ -14,37 +14,42 @@ FROM ${ENGINE_IMAGE}
 
 # Override the inherited pipeline OCI labels
 LABEL org.opencontainers.image.title="Log10x Compiler"
-LABEL org.opencontainers.image.description="Log10x AOT symbol compiler: pipeline-10x plus the source-fetch toolchain (git, docker CLI, helm)"
+LABEL org.opencontainers.image.description="Log10x AOT symbol compiler: pipeline-10x plus the source-fetch toolchain (git, podman, helm)"
 LABEL org.opencontainers.image.source="https://github.com/log-10x/docker-images"
 
 ARG TARGETPLATFORM
-# Pinned versions of the bundled source-fetch CLIs (bump as needed).
-ARG DOCKER_CLI_VERSION=27.3.1
+# Pinned version of the bundled helm CLI (bump as needed).
 ARG HELM_VERSION=v3.16.4
 
 USER root
 
 # Source-fetch toolchain for the compile 'pull' stage:
-#   git        - pull source from git repos
-#   docker CLI - docker-image pull/scan (client only; needs a mounted
-#                /var/run/docker.sock or a remote DOCKER_HOST at runtime)
-#   helm       - pull/render Helm charts
+#   git     - pull source from git repos
+#   podman  - docker-image pull/scan, DAEMONLESS. The engine materializes an
+#             image's filesystem by shelling out to `docker create` + `docker
+#             export`; podman runs those verbs with no daemon and no host socket.
+#             Symlinked as /usr/local/bin/docker so the engine's default
+#             `command` uses it unchanged. Runtime image pull needs CAP_SYS_ADMIN
+#             plus STORAGE_DRIVER=vfs (set below); no /var/run/docker.sock mount.
+#   helm    - pull/render Helm charts
 # Drop the inherited fluent-bit repo file first so this install doesn't try to
 # refresh it over the network (fluent-bit itself stays installed from the base).
 RUN rm -f /etc/yum.repos.d/fluent-bit.repo && \
-    microdnf install -y git tar gzip && \
+    microdnf install -y git tar gzip podman && \
+    ln -sf /usr/bin/podman /usr/local/bin/docker && \
     case "${TARGETPLATFORM:-linux/amd64}" in \
-      "linux/arm64") DOCKER_ARCH=aarch64 ; HELM_ARCH=arm64 ;; \
-      *)             DOCKER_ARCH=x86_64  ; HELM_ARCH=amd64 ;; \
+      "linux/arm64") HELM_ARCH=arm64 ;; \
+      *)             HELM_ARCH=amd64 ;; \
     esac && \
-    curl -fsSL "https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_CLI_VERSION}.tgz" \
-      | tar -xz -C /tmp docker/docker && \
-    install -m 0755 /tmp/docker/docker /usr/local/bin/docker && \
     curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${HELM_ARCH}.tar.gz" \
       | tar -xz -C /tmp && \
     install -m 0755 /tmp/linux-${HELM_ARCH}/helm /usr/local/bin/helm && \
-    rm -rf /tmp/docker /tmp/linux-${HELM_ARCH} && \
+    rm -rf /tmp/linux-${HELM_ARCH} && \
     microdnf clean all
+
+# Daemonless podman uses vfs storage (overlay would need /dev/fuse plus a device
+# plugin in k8s); vfs works with just CAP_SYS_ADMIN at runtime.
+ENV STORAGE_DRIVER=vfs
 
 USER tenxuser
 


### PR DESCRIPTION
## What
Make the prod `compiler-10x` image **self-contained** for docker-image pull: replace the bundled docker static CLI with **podman**, so the compiler pulls docker/OCI images for symbol scanning with **no docker daemon and no mounted host socket**.

## Why
The compiler's docker pull source shells out to `docker create` + `docker export` to materialize an image's filesystem (no `docker pull`/`save`, no registry HTTP client). The docker *CLI* alone can't do that without a daemon, so the old image needed a mounted `/var/run/docker.sock` (host-docker blast radius) or a remote `DOCKER_HOST`. podman runs the same verbs daemonless.

## How
- `microdnf install podman`, drop the docker-static-binary download
- symlink `/usr/local/bin/docker` -> podman, so the engine's default `command` is unchanged (no config/modules change)
- `ENV STORAGE_DRIVER=vfs` (overlay would need `/dev/fuse` + a device plugin in k8s)
- keep `git` + `helm`; fluent-bit still inherited from pipeline-10x

## Runtime
Image pull needs **`CAP_SYS_ADMIN`** (not `--privileged`, no host socket). github/helm/artifactory/gomod stay HTTPS-only with zero extra privilege.

## Companion
Mirrors the dev image change in engine PR https://github.com/log-10x/engine/pull/56. Validated: podman 4.9.4 (UBI8) and 5.8 rootless as tenxuser uid 1000 — create returns a 64-hex id, manifest inspect yields the engine's JSONPath shape, export streams the rootfs tar.
