### PR TITLE
docs(readme): UTM-tag links + fix broken doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ Every image ships with a built-in **limited** license so it runs out of the box.
 ```
 
 **Get a Log10x License:**
-- [Pricing](https://log10x.com/pricing)
+- [Pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=footer)
 - [Documentation](https://doc.log10x.com)
 - [Contact Sales](mailto:sales@log10x.com)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🔟❎ Docker Images
 
-This repository holds and publishes the docker files for the public releases of [Log10x](https://doc.log10x.com).
+This repository holds and publishes the docker files for the public releases of [Log10x](https://www.log10x.com/?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=hero).
 
 Log10x is an **Observability runtime**, it is to log/trace data what Chrome V8 is to JavaScript:
 an engine for dynamically optimizing execution with the goal improving performance and reducing the cost of data processing.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Visit our [Docker deployment](https://doc.log10x.com/install/docker/) documentat
 
 Docker image of a [Quarkus](https://quarkus.io/) server capable of invoking [Log10x pipelines](https://doc.log10x.com/engine/pipeline/) on demand with [Log10x Cloud](https://doc.log10x.com/engine/flavors/#cloud) capabilities.
 
-Visit our [Cloud Streamer deployment](https://doc.log10x.com/apps/cloud/streamer/deploy/) documentation for more info about using this image.
+Visit our [Docker deployment](https://doc.log10x.com/install/docker/) documentation for more info about using this image.
 
 ## License
 

--- a/edge/README.md
+++ b/edge/README.md
@@ -9,7 +9,7 @@ Run the latest release with:
 docker run ghcr.io/log-10x/edge-10x:latest
 ```
 
-The image ships with a built-in limited license. For the full engine, download your own from [console.log10x.com](https://console.log10x.com) and pass it as `-e TENX_LICENSE_KEY="$(cat license.jwt)"`. See [log10x.com/pricing](https://log10x.com/pricing).
+The image ships with a built-in limited license. For the full engine, download your own from [console.log10x.com](https://console.log10x.com) and pass it as `-e TENX_LICENSE_KEY="$(cat license.jwt)"`. See [log10x.com/pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=inline).
 
 ## Under the hood
 

--- a/edge/README.md
+++ b/edge/README.md
@@ -1,6 +1,6 @@
 # 🔟❎ Edge
 
-Docker image of a lightweight Debian (bookworm-slim) container with [Log10x Edge](https://doc.log10x.com/architecture/flavors/#edge) as a GraalVM native binary.
+Docker image of a lightweight Debian (bookworm-slim) container with [Log10x Edge](https://doc.log10x.com/engine/flavors/#edge) as a GraalVM native binary.
 
 ## Quick start
 

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -27,7 +27,7 @@ Entry point: `com.log10x.ext.lambda.RetrieverHandler::handleRequest`.
 
 ## License
 
-The image ships with a built-in limited license. For the full engine, set the Lambda function's `TENX_LICENSE_KEY` env var to a JWT downloaded from [console.log10x.com](https://console.log10x.com) — the `terraform-aws-tenx-retriever-lambda` module exposes it as an input variable. See [log10x.com/pricing](https://log10x.com/pricing).
+The image ships with a built-in limited license. For the full engine, set the Lambda function's `TENX_LICENSE_KEY` env var to a JWT downloaded from [console.log10x.com](https://console.log10x.com) — the `terraform-aws-tenx-retriever-lambda` module exposes it as an input variable. See [log10x.com/pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=inline).
 
 ## Manual build (only for debugging the Dockerfile)
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -9,7 +9,7 @@ Run the latest release with:
 docker run ghcr.io/log-10x/log10x-pipeline:latest
 ```
 
-The image ships with a built-in limited license. For the full engine, download your own from [console.log10x.com](https://console.log10x.com) and pass it as `-e TENX_LICENSE_KEY="$(cat license.jwt)"`. See [log10x.com/pricing](https://log10x.com/pricing).
+The image ships with a built-in limited license. For the full engine, download your own from [console.log10x.com](https://console.log10x.com) and pass it as `-e TENX_LICENSE_KEY="$(cat license.jwt)"`. See [log10x.com/pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=inline).
 
 ## Under the hood
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -16,7 +16,7 @@ The image ships with a built-in limited license. For the full engine, download y
 This image is bundled with all the tools that are required by Log10x cloud to work:
 
 - binutils and python39, which are needed for the [compile](https://doc.log10x.com/compile/) pipeline
-- [Fluentbit](https://fluentbit.io/), allowing for [cloud analyzer query](https://doc.log10x.com/apps/cloud/streamer/#query) to emit data your destination of chioce.
+- [Fluentbit](https://fluentbit.io/), allowing pipeline output to be emitted to your destination of choice.
 
 Visit our [pipeline deployment](https://doc.log10x.com/install/docker/) documentation for more info about using this image.
 

--- a/quarkus/README.md
+++ b/quarkus/README.md
@@ -18,9 +18,9 @@ This image is built on [Quarkus](https://quarkus.io/), the Supersonic Subatomic 
 Additionally, this image is bundled with all the tools that are required by Log10x cloud to work:
 
 - binutils and python39, which are needed for the [compile](https://doc.log10x.com/compile/) pipeline
-- [Fluentbit](https://fluentbit.io/), allowing for [cloud analyzer query](https://doc.log10x.com/apps/cloud/streamer/#query) to emit data your destination of chioce.
+- [Fluentbit](https://fluentbit.io/), allowing pipeline output to be emitted to your destination of choice.
 
-Visit our [Cloud Streamer deployment](https://doc.log10x.com/apps/cloud/streamer/deploy/) documentation for more info about using this image.
+Visit our [Docker deployment](https://doc.log10x.com/install/docker/) documentation for more info about using this image.
 
 ## K8 Deployment
 

--- a/quarkus/README.md
+++ b/quarkus/README.md
@@ -9,7 +9,7 @@ Run the latest release with:
 docker run ghcr.io/log-10x/log10x-quarkus:latest
 ```
 
-The image ships with a built-in limited license. For the full engine, download your own from [console.log10x.com](https://console.log10x.com) and pass it as `-e TENX_LICENSE_KEY="$(cat license.jwt)"`. See [log10x.com/pricing](https://log10x.com/pricing).
+The image ships with a built-in limited license. For the full engine, download your own from [console.log10x.com](https://console.log10x.com) and pass it as `-e TENX_LICENSE_KEY="$(cat license.jwt)"`. See [log10x.com/pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=inline).
 
 ## Under the hood
 


### PR DESCRIPTION
This PR does two things to the README, both verified:

1. **UTM-tags** the www.log10x.com link(s) (`utm_source=github&utm_medium=readme&utm_campaign=docker-images`) so GitHub-sourced traffic is attributable.
2. **Fixes broken doc.log10x.com links** (404s) by repointing to current, HTTP-verified pages:
   - `apps/cloud/streamer/deploy/` -> `install/docker/`; dropped dead `apps/cloud/streamer/#query` (reworded the Fluentbit line); `architecture/flavors` -> `engine/flavors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)