### PR TITLE
ci: run the edge image before :latest points at it

### DIFF
--- a/.github/workflows/publish_10x_edge.yaml
+++ b/.github/workflows/publish_10x_edge.yaml
@@ -199,12 +199,89 @@ jobs:
       dockerhub_repo: ${{ needs.prepare.outputs.dockerhub_repo }}
     secrets: inherit
 
+  # Run the image before :latest points at it.
+  #
+  # The engine BINARY is behaviourally gated upstream: engine's build_all runs a
+  # native smoke on four platforms and blocks the release if a metric registry was
+  # dead-code-eliminated. None of that covers the IMAGE. Layer layout, TENX_HOME /
+  # TENX_CONFIG / TENX_MODULES paths, the entrypoint, the USER directive and file
+  # permissions are assembled here and were never executed -- `grep -rn "docker run"`
+  # across all 12 workflows in this repo returned zero.
+  #
+  # That is the same defect engine#78 fixed one layer down, and it lands on the
+  # artifact customers actually pull: every sidecar overlay in the Receiver docs
+  # pins edge-10x:latest.
+  #
+  # Pulls the PUSHED image back from the registry rather than testing a local
+  # build, so this verifies the bytes that shipped.
+  smoke_x86:
+    name: "Smoke x86 image ${{needs.prepare.outputs.version_tag}}"
+    needs:
+      - prepare
+      - publish_x86
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run the pushed image
+        run: |
+          IMAGE="${{needs.prepare.outputs.docker_repo}}/${{needs.prepare.outputs.image_name}}:${{needs.prepare.outputs.version_tag}}-amd64"
+          echo "pulling $IMAGE"
+          docker pull "$IMAGE"
+          OUT=$(docker run --rm "$IMAGE" --version 2>&1 | head -3)
+          echo "$OUT"
+          echo "$OUT" | grep -q "10x engine" || {
+            echo "::error::the pushed image did not report an engine version. The binary is gated upstream, so this is the image assembly: entrypoint, TENX_HOME layout, or permissions."
+            exit 1
+          }
+          echo "$OUT" | grep -q "${{needs.prepare.outputs.version_tag}}" || {
+            echo "::error::image reports a different version than the tag it was pushed under. Expected ${{needs.prepare.outputs.version_tag}}."
+            exit 1
+          }
+
+  smoke_aarch64:
+    name: "Smoke aarch64 image ${{needs.prepare.outputs.version_tag}}"
+    needs:
+      - prepare
+      - publish_aarch64
+    runs-on: linux-arm64-2core
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run the pushed image
+        run: |
+          IMAGE="${{needs.prepare.outputs.docker_repo}}/${{needs.prepare.outputs.image_name}}:${{needs.prepare.outputs.version_tag}}-aarch64"
+          echo "pulling $IMAGE"
+          docker pull "$IMAGE"
+          OUT=$(docker run --rm "$IMAGE" --version 2>&1 | head -3)
+          echo "$OUT"
+          echo "$OUT" | grep -q "10x engine" || {
+            echo "::error::the pushed image did not report an engine version. The binary is gated upstream, so this is the image assembly: entrypoint, TENX_HOME layout, or permissions."
+            exit 1
+          }
+          echo "$OUT" | grep -q "${{needs.prepare.outputs.version_tag}}" || {
+            echo "::error::image reports a different version than the tag it was pushed under. Expected ${{needs.prepare.outputs.version_tag}}."
+            exit 1
+          }
+
   publish_latest_manifest:
     name: Publish multiarch manifest for latest
     needs:
       - prepare
       - publish_x86
       - publish_aarch64
+      - smoke_x86
+      - smoke_aarch64
     uses: ./.github/workflows/update_multiarch_manifest.yaml
     with:
       version_tag: latest


### PR DESCRIPTION
`grep -rn "docker run"` across all **12 workflows** in this repo returns **zero**. The image is assembled, pushed, and `:latest` is moved onto it without anything ever executing it.

The engine **binary** is behaviourally gated upstream — engine#78 added a native smoke on four platforms to `build_all` and blocks the release if a metric registry was dead-code-eliminated. None of that covers the **image**. Layer layout, the `TENX_HOME`/`TENX_CONFIG`/`TENX_MODULES` paths, the entrypoint, the `USER` directive and file permissions are assembled *here*, and were verified by nothing.

Same defect as engine#78, one layer down, landing on the artifact customers actually pull: every sidecar overlay in the Receiver docs pins `edge-10x:latest`.

## What this adds

`smoke_x86` and `smoke_aarch64` pull the **pushed** image back from the registry and run it, asserting it reports an engine version and that the version matches the tag it was pushed under. `publish_latest_manifest` now needs both, so `:latest` cannot move onto an image nobody has run.

Pulling the pushed tag rather than testing a local build is deliberate — otherwise the bytes verified are not the bytes shipped.

## Verified the assertion itself

The entrypoint is `sh -c 'exec $TENX_BIN "${@}"'`, so it was worth checking `--version` survives it rather than assuming:

```
$ docker run --rm log10x/edge-10x:latest --version
10x engine v1.1.6, flavor: 'edge'
exit 0
```

Incidentally that is the live customer-facing state: `edge-10x:latest` today is **1.1.6**, the binary with three pruned metric registries requiring `GLIBC_2.34`.

This gate would **not** have stopped that — 1.1.6 starts fine and prints a version. The upstream release gate does. This stops the narrower case where a good binary is assembled into an image that cannot start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)