### PR TITLE
fix(fwd): create the engine log dir and log to stdout — filebeat cannot start without it

### DIFF
--- a/fwd/filebeat/Dockerfile
+++ b/fwd/filebeat/Dockerfile
@@ -76,4 +76,30 @@ COPY --from=tenx-builder $TENX_HOME $TENX_HOME
 
 # Switch back tothe filebeat user, same as original image
 #
+# Create the engine's log directory and default its logs to stdout.
+#
+# Without this the image CANNOT START. The engine's default log4j2 appender is
+# tenxFileAppender at /var/log/tenx/tenx.log; the directory does not exist, and
+# for filebeat the image ends on a non-root USER that cannot create it. The
+# RollingFileAppender then fails to construct and that failure is FATAL:
+#
+#   Caused by: java.io.IOException: Could not create directory /var/log/tenx
+#   -> could not launch pipeline: 'run'
+#
+# Measured on the published log10x/filebeat-10x:1.1.25-native, same image, same
+# config, same license, only the user differing:
+#
+#   as USER filebeat (shipped default)   launch fails
+#   as root                              0 launch failures
+#
+# edge-10x has had both lines since it was written, which is why it works. The
+# forwarders never got them.
+#
+# The console appender is also the right default for a container regardless:
+# with the file appender only the startup banner reaches stdout, so `kubectl
+# logs` shows a healthy-looking pod while every WARN, ERROR and stack trace goes
+# to a file nobody reads. Set TENX_LOG_APPENDER=tenxFileAppender to opt back in.
+RUN mkdir -p /var/log/tenx && chmod 777 /var/log/tenx
+ENV TENX_LOG_APPENDER=tenxConsoleAppender
+
 USER filebeat

--- a/fwd/fluent-bit/Dockerfile
+++ b/fwd/fluent-bit/Dockerfile
@@ -72,3 +72,29 @@ COPY --from=tenx-builder /bin/dash /bin/sh
 COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
 COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
 COPY --from=tenx-builder $TENX_HOME $TENX_HOME
+
+# Create the engine's log directory and default its logs to stdout.
+#
+# Without this the image CANNOT START. The engine's default log4j2 appender is
+# tenxFileAppender at /var/log/tenx/tenx.log; the directory does not exist, and
+# for filebeat the image ends on a non-root USER that cannot create it. The
+# RollingFileAppender then fails to construct and that failure is FATAL:
+#
+#   Caused by: java.io.IOException: Could not create directory /var/log/tenx
+#   -> could not launch pipeline: 'run'
+#
+# Measured on the published log10x/filebeat-10x:1.1.25-native, same image, same
+# config, same license, only the user differing:
+#
+#   as USER filebeat (shipped default)   launch fails
+#   as root                              0 launch failures
+#
+# edge-10x has had both lines since it was written, which is why it works. The
+# forwarders never got them.
+#
+# The console appender is also the right default for a container regardless:
+# with the file appender only the startup banner reaches stdout, so `kubectl
+# logs` shows a healthy-looking pod while every WARN, ERROR and stack trace goes
+# to a file nobody reads. Set TENX_LOG_APPENDER=tenxFileAppender to opt back in.
+RUN mkdir -p /var/log/tenx && chmod 777 /var/log/tenx
+ENV TENX_LOG_APPENDER=tenxConsoleAppender

--- a/fwd/fluentd/Dockerfile
+++ b/fwd/fluentd/Dockerfile
@@ -63,3 +63,29 @@ ENV TENX_CONFIG=/etc/tenx/config
 COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
 COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
 COPY --from=tenx-builder $TENX_HOME $TENX_HOME
+
+# Create the engine's log directory and default its logs to stdout.
+#
+# Without this the image CANNOT START. The engine's default log4j2 appender is
+# tenxFileAppender at /var/log/tenx/tenx.log; the directory does not exist, and
+# for filebeat the image ends on a non-root USER that cannot create it. The
+# RollingFileAppender then fails to construct and that failure is FATAL:
+#
+#   Caused by: java.io.IOException: Could not create directory /var/log/tenx
+#   -> could not launch pipeline: 'run'
+#
+# Measured on the published log10x/filebeat-10x:1.1.25-native, same image, same
+# config, same license, only the user differing:
+#
+#   as USER filebeat (shipped default)   launch fails
+#   as root                              0 launch failures
+#
+# edge-10x has had both lines since it was written, which is why it works. The
+# forwarders never got them.
+#
+# The console appender is also the right default for a container regardless:
+# with the file appender only the startup banner reaches stdout, so `kubectl
+# logs` shows a healthy-looking pod while every WARN, ERROR and stack trace goes
+# to a file nobody reads. Set TENX_LOG_APPENDER=tenxFileAppender to opt back in.
+RUN mkdir -p /var/log/tenx && chmod 777 /var/log/tenx
+ENV TENX_LOG_APPENDER=tenxConsoleAppender


### PR DESCRIPTION
The published `log10x/filebeat-10x:1.1.25-native` **cannot launch its pipeline**.

```
Caused by: java.io.IOException: Could not create directory /var/log/tenx
-> could not launch pipeline: 'run'
```

The engine default log4j2 appender is `tenxFileAppender` at `/var/log/tenx/tenx.log`. The directory does not exist in the image, and the image ends on `USER filebeat`, which cannot create it. `RollingFileAppender` then fails to construct — and that failure is **fatal to the launch**, not merely a lost log.

## Isolated, not inferred

Same published image, same `filebeat.yml`, same license, only the user differing:

```
as USER filebeat (shipped default)   launch-failures: 1, /var/log/tenx errors: 1
as root                              launch-failures: 0, /var/log/tenx errors: 0
```

## Why edge-10x works and the forwarders do not

`edge-10x` has had both mitigations since it was written:

```
RUN mkdir -p /var/log/tenx && chmod 777 /var/log/tenx
ENV TENX_LOG_APPENDER=tenxConsoleAppender
USER tenxuser
```

All three forwarders had neither. Only filebeat sets a non-root `USER`, so only filebeat is fatal — fluent-bit and fluentd run as root and create the directory by accident.

## The second half, which affects all three

With the file appender only the startup banner reaches stdout. Every WARN, ERROR and stack trace goes to a file nobody reads, so `kubectl logs` shows a healthy-looking pod while the engine is failing — and `kubectl logs` is the first step in the Datadog troubleshooting page. Console is the right default for a container regardless; `TENX_LOG_APPENDER=tenxFileAppender` opts back in.

## How this survived

The image builds green, pushes green, pulls fine, and `--version` prints correctly. **Every check short of running the real filebeat entrypoint passes.** docker-images had zero `docker run` across twelve workflows until #10 — and that gate checks `--version`, which this defect does not affect. Worth extending it to a real entrypoint run.

## Not fixed here

filebeat did not harvest the test file in either run, so **end-to-end event flow through the image remains unverified**. That is a separate question from the launch failure isolated above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)