### PR TITLE
fix(fwd): set filebeatLogsPath, the second thing stopping filebeat-10x launching

### DIFF
--- a/fwd/filebeat/Dockerfile
+++ b/fwd/filebeat/Dockerfile
@@ -102,4 +102,36 @@ COPY --from=tenx-builder $TENX_HOME $TENX_HOME
 RUN mkdir -p /var/log/tenx && chmod 777 /var/log/tenx
 ENV TENX_LOG_APPENDER=tenxConsoleAppender
 
+# Second launch blocker, same shape as the one above, one layer deeper.
+#
+# The filebeat module's log4j2.yaml declares a filebeatRollingFile appender that
+# replays Filebeat's own log lines to wherever Filebeat would have written them:
+#
+#   fileName: "${env:filebeatPath:-${env:filebeatLogsPath}}..."
+#
+# log4j2 does NOT recurse into a `:-` default, so with both variables unset the
+# name resolves to the literal string, and log4j2 builds appenders eagerly --
+# a threshold filter that would disable this one does not stop construction:
+#
+#   Could not create directory /usr/share/filebeat/${env:filebeatLogsPath}
+#   -> could not launch pipeline: 'run'
+#
+# The module intends these to come from Filebeat's startup banner, parsed off
+# the pipe by the `match` extractor in stream.yaml. Measured: the banner does
+# reach the engine (teed the pipe and found it on line 1, and the module's regex
+# matches it), yet the value never lands here -- these lookups read
+# System.getenv, which the engine cannot populate for its own process.
+#
+# So the variable has to be set in the environment, and /usr/share/filebeat/logs
+# is exactly the Logs path Filebeat reports in that banner. It already exists in
+# the base image and is group-writable by uid 1000. Override it if Filebeat is
+# reconfigured with a different logging.files.path.
+#
+# Verified on log10x/filebeat-10x:1.1.25-native with the documented Receiver
+# config, unset vs set, nothing else differing:
+#
+#   filebeatLogsPath unset   2 launch failures, 0 events shipped
+#   filebeatLogsPath set     0 launch failures, events shipped to the destination
+ENV filebeatLogsPath=/usr/share/filebeat/logs
+
 USER filebeat


### PR DESCRIPTION
docker-images#11 fixed /var/log/tenx. Behind it sat a second fatal error in the
same class, and the image still could not launch its pipeline:

  Could not create directory /usr/share/filebeat/${env:filebeatLogsPath}
  -> could not launch pipeline: 'run'

The filebeat module's log4j2.yaml declares a filebeatRollingFile appender that
replays Filebeat's own log lines to wherever Filebeat would have written them:

  fileName: "${env:filebeatPath:-${env:filebeatLogsPath}}..."

log4j2 does not recurse into a ':-' default, so with both variables unset the
name resolves to that inner text literally. log4j2 also constructs appenders
eagerly, so the thresholdFilter that would disable this one does not prevent
construction, and the failure is fatal to the launch rather than a lost log.

WHY THE VARIABLE IS NOT ALREADY SET

The module intends these to come from Filebeat's startup banner, parsed off the
pipe by the `match` extractor in stream.yaml. Measured, not assumed: the banner
does reach the engine. Teeing the pipe shows it arriving on line 1, well inside
the module's maxLines of 20, and the module's regex matches that exact line.

The value still never lands, because these lookups read System.getenv, which the
engine cannot populate for its own process. Confirmed from the other direction
by setting logging.files.path in filebeat.yml, which feeds filebeatPath through
the same stream.yaml re-parse: the identical literal still appears.

So the variable has to come from the environment.
/usr/share/filebeat/logs is exactly the Logs path Filebeat reports in its own
banner, already exists in the base image, and is group-writable by uid 1000.

VERIFIED BY RUNNING IT, NOT BY READING IT

Published log10x/filebeat-10x:1.1.25-native, the documented Receiver config from
doc.log10x.com (script processor on the input, unix return path, output.file),
a real license, nothing else differing:

  filebeatLogsPath unset   2 launch failures, 0 events shipped
  filebeatLogsPath set     0 launch failures, 4 records shipped

Then rebuilt from this Dockerfile and run with no runtime override at all: 0
launch failures, and the same 4 records reached the destination, each carrying
the engine-stamped tenx_hash. Six input lines become four records because the
grouping module consolidates the multiline pairs.

The full documented path ran end to end: file, filestream input, script
processor, stdout, engine, unix socket, output.file.

NOT A PERMANENT HOME FOR THIS LINE

The underlying defect is in the module config and is fixed separately in
log-10x/modules. Modules ship inside the release (the image's copy is
byte-identical to modules origin/main), so that fix only reaches images on the
next release. This ENV makes 1.1.25 work now and can be dropped once a release
carrying the module fix is out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)