### PR TITLE
ci(lambda): publish a multiarch :latest manifest like every other image

### DIFF
--- a/.github/workflows/publish_10x_lambda.yaml
+++ b/.github/workflows/publish_10x_lambda.yaml
@@ -236,3 +236,18 @@ jobs:
       image_name: ${{needs.prepare.outputs.image_name}}
       dockerhub_repo: ${{needs.prepare.outputs.dockerhub_repo}}
     secrets: inherit
+
+  publish_latest_manifest:
+    name: Publish multiarch manifest for latest
+    needs:
+      - prepare
+      - publish_x86
+      - publish_aarch64
+    uses: ./.github/workflows/update_multiarch_manifest.yaml
+    with:
+      version_tag: latest
+      docker_hub: ${{ inputs.docker_hub }}
+      docker_repo: ${{needs.prepare.outputs.docker_repo}}
+      image_name: ${{needs.prepare.outputs.image_name}}
+      dockerhub_repo: ${{needs.prepare.outputs.dockerhub_repo}}
+    secrets: inherit


### PR DESCRIPTION
`publish_10x_lambda.yaml` has `publish_version_manifest` but no `publish_latest_manifest`. Edge, pipeline, quarkus and compiler all have both.

**Verified against the registry** right after publishing 1.1.37 to all five images:

| image | :latest resolves to 1.1.37 |
|---|---|
| edge-10x | yes |
| pipeline-10x | yes |
| compiler-10x | yes |
| quarkus-10x | yes |
| lambda-10x | **no** |

`lambda-10x:latest` also reports **0 architecture entries** against **2** on `:1.1.37`, so it is a single-arch image while the others are multiarch manifest lists.

Gated on the same jobs as `publish_version_manifest`; lambda has no smoke jobs to depend on, unlike edge.