### PR TITLE
Build the runtime flavor; drop the JIT forwarder images

### DIFF
--- a/.github/workflows/publish_10x_all_containers.yaml
+++ b/.github/workflows/publish_10x_all_containers.yaml
@@ -124,9 +124,11 @@ jobs:
       docker_hub: ${{ inputs.docker_hub }}
     secrets: inherit
 
-  # The native flavor does NOT need Quarkus first: it stages tenx-home from the
-  # release's own config/modules/symbols artifacts rather than pulling it out of
-  # a quarkus-10x tag. Only `prepare`.
+  # The native Lambda image does NOT need Quarkus first: it stages tenx-home
+  # from the release's own config/modules/symbols artifacts rather than pulling
+  # it out of a quarkus-10x tag. Only `prepare`. ("native" here is the Lambda
+  # image packaging variant, jvm|native -- not an engine flavor. The engine
+  # flavors are compiler|runtime; see pipeline-releases/FLAVORS.md.)
   LambdaNative:
     if: ${{ inputs.publish_lambda }}
     needs:

--- a/.github/workflows/publish_10x_all_forwarders.yaml
+++ b/.github/workflows/publish_10x_all_forwarders.yaml
@@ -1,5 +1,10 @@
 name: Publish All 10x forwarders
 
+# NOTE: the JIT builds are GONE. They installed the jpackage 'edge' flavor,
+# which is retired (see pipeline-releases/FLAVORS.md), and they produced the
+# -jit / -jit-debug tag suffixes. Tags already published keep working; no new
+# ones are cut. Every forwarder now builds the runtime flavor only.
+#
 # NOTE: the Fluent Bit and Fluentd toggles below are RETIRED (image-swap model).
 # Fluentd/Fluent Bit now run 10x as a separate log10x/edge-10x SIDECAR container on
 # the upstream fluent charts, not a baked image. Kept for legacy rebuilds only --
@@ -79,34 +84,20 @@ jobs:
             echo "release_version=$LATEST" >> "$GITHUB_OUTPUT"
           fi
 
-  filebeat-jit:
-    if: ${{ inputs.publish_filebeat }}
-    name: Filebeat JIT
-    uses: ./.github/workflows/publish_10x_forwarder.yaml
-    needs:
-      - prepare
-    with:
-      release_version: ${{ needs.prepare.outputs.release_version }}
-      docker_hub: ${{ inputs.docker_hub }}
-      forwarder_type: Filebeat
-      tenx_dist: Edge
-    secrets: inherit
-
   # The ONLY job that may move :latest.
   #
-  # Four flavors are built per forwarder (jit, native, and the two debug
-  # variants) and they all finish around the same time, so more than one setting
-  # publish_latest would race for the same tag and the winner would be whichever
-  # runner happened to finish last.
+  # Two images are built per forwarder (standard and debug) and they finish
+  # around the same time, so more than one setting publish_latest would race for
+  # the same tag and the winner would be whichever runner happened to finish
+  # last.
   #
-  # Native rather than jit because that is the flavor GA ships and the one the
-  # Receiver docs are moving to. Filebeat rather than the others because the
-  # Fluent Bit and Fluentd image builds are retired (see the note at the top of
-  # publish_10x_forwarder.yaml); those forwarders run edge-10x as a sidecar and
-  # neither image is referenced anywhere in the docs.
-  filebeat-native:
+  # Filebeat rather than the others because the Fluent Bit and Fluentd image
+  # builds are retired (see the note at the top of publish_10x_forwarder.yaml);
+  # those forwarders run edge-10x as a sidecar and neither image is referenced
+  # anywhere in the docs.
+  filebeat:
     if: ${{ inputs.publish_filebeat }}
-    name: Filebeat Native
+    name: Filebeat
     uses: ./.github/workflows/publish_10x_forwarder.yaml
     needs:
       - prepare
@@ -114,13 +105,13 @@ jobs:
       release_version: ${{ needs.prepare.outputs.release_version }}
       docker_hub: ${{ inputs.docker_hub }}
       forwarder_type: Filebeat
-      tenx_dist: Native
+      tenx_dist: Runtime
       publish_latest: true
     secrets: inherit
 
-  filebeat-debug-jit:
+  filebeat-debug:
     if: ${{ inputs.publish_filebeat_debug }}
-    name: Filebeat Debug JIT
+    name: Filebeat Debug
     uses: ./.github/workflows/publish_10x_forwarder.yaml
     needs:
       - prepare
@@ -128,25 +119,12 @@ jobs:
       release_version: ${{ needs.prepare.outputs.release_version }}
       docker_hub: ${{ inputs.docker_hub }}
       forwarder_type: Filebeat-Debug
-      tenx_dist: Edge
+      tenx_dist: Runtime
     secrets: inherit
 
-  filebeat-debug-native:
-    if: ${{ inputs.publish_filebeat_debug }}
-    name: Filebeat Debug Native
-    uses: ./.github/workflows/publish_10x_forwarder.yaml
-    needs:
-      - prepare
-    with:
-      release_version: ${{ needs.prepare.outputs.release_version }}
-      docker_hub: ${{ inputs.docker_hub }}
-      forwarder_type: Filebeat-Debug
-      tenx_dist: Native
-    secrets: inherit
-
-  fluent-bit-jit:
+  fluent-bit:
     if: ${{ inputs.publish_fluent_bit }}
-    name: Fluent-Bit JIT
+    name: Fluent-Bit
     uses: ./.github/workflows/publish_10x_forwarder.yaml
     needs:
       - prepare
@@ -154,25 +132,12 @@ jobs:
       release_version: ${{ needs.prepare.outputs.release_version }}
       docker_hub: ${{ inputs.docker_hub }}
       forwarder_type: Fluent-Bit
-      tenx_dist: Edge
+      tenx_dist: Runtime
     secrets: inherit
 
-  fluent-bit-native:
-    if: ${{ inputs.publish_fluent_bit }}
-    name: Fluent-Bit Native
-    uses: ./.github/workflows/publish_10x_forwarder.yaml
-    needs:
-      - prepare
-    with:
-      release_version: ${{ needs.prepare.outputs.release_version }}
-      docker_hub: ${{ inputs.docker_hub }}
-      forwarder_type: Fluent-Bit
-      tenx_dist: Native
-    secrets: inherit
-
-  fluent-bit-debug-jit:
+  fluent-bit-debug:
     if: ${{ inputs.publish_fluent_bit_debug }}
-    name: Fluent-Bit Debug JIT
+    name: Fluent-Bit Debug
     uses: ./.github/workflows/publish_10x_forwarder.yaml
     needs:
       - prepare
@@ -180,25 +145,12 @@ jobs:
       release_version: ${{ needs.prepare.outputs.release_version }}
       docker_hub: ${{ inputs.docker_hub }}
       forwarder_type: Fluent-Bit-Debug
-      tenx_dist: Edge
+      tenx_dist: Runtime
     secrets: inherit
 
-  fluent-bit-debug-native:
-    if: ${{ inputs.publish_fluent_bit_debug }}
-    name: Fluent-Bit Debug Native
-    uses: ./.github/workflows/publish_10x_forwarder.yaml
-    needs:
-      - prepare
-    with:
-      release_version: ${{ needs.prepare.outputs.release_version }}
-      docker_hub: ${{ inputs.docker_hub }}
-      forwarder_type: Fluent-Bit-Debug
-      tenx_dist: Native
-    secrets: inherit
-
-  fluentd-jit:
+  fluentd:
     if: ${{ inputs.publish_fluentd }}
-    name: Fluentd JIT
+    name: Fluentd
     uses: ./.github/workflows/publish_10x_forwarder.yaml
     needs:
       - prepare
@@ -206,18 +158,5 @@ jobs:
       release_version: ${{ needs.prepare.outputs.release_version }}
       docker_hub: ${{ inputs.docker_hub }}
       forwarder_type: Fluentd
-      tenx_dist: Edge
-    secrets: inherit
-
-  fluentd-native:
-    if: ${{ inputs.publish_fluentd }}
-    name: Fluentd Native
-    uses: ./.github/workflows/publish_10x_forwarder.yaml
-    needs:
-      - prepare
-    with:
-      release_version: ${{ needs.prepare.outputs.release_version }}
-      docker_hub: ${{ inputs.docker_hub }}
-      forwarder_type: Fluentd
-      tenx_dist: Native
+      tenx_dist: Runtime
     secrets: inherit

--- a/.github/workflows/publish_10x_forwarder.yaml
+++ b/.github/workflows/publish_10x_forwarder.yaml
@@ -37,8 +37,7 @@ on:
         type: choice
         description: Type of artifact
         options:
-          - Edge
-          - Native
+          - Runtime
       publish_latest:
         required: false
         default: false
@@ -68,9 +67,9 @@ on:
 
           No forwarder repo has ever had a :latest tag; filebeat-10x has 207
           tags and not one of them is latest, so the Receiver docs pin an exact
-          version. Only ONE of the four flavors this workflow builds (jit,
-          native, and the two debug variants) may set this, or they race for
-          the same tag. The orchestrator sets it on Native only.
+          version. Only ONE of the variants this workflow builds (the standard
+          and debug images) may set this, or they race for the same tag. The
+          orchestrator sets it on the standard Filebeat build only.
 
 jobs:
   prepare:
@@ -99,8 +98,16 @@ jobs:
               core.setFailed("Only Filebeat/Filebeat-Debug/Fluent-Bit/Fluent-Bit-Debug/Fluentd forwarders are supported")
             }
 
-            if ("${{ inputs.tenx_dist }}" != "Edge" && "${{ inputs.tenx_dist }}" != "Native") {
-              core.setFailed("Only Edge/Native dists are supported")
+            // "Native" is the old spelling of "Runtime" and still resolves, so
+            // an in-flight workflow_dispatch does not fail on the rename.
+            // "Edge" named the retired jpackage JIT build and is rejected
+            // outright -- install.sh no longer accepts --flavor edge, so a build
+            // that got this far would fail later and less clearly.
+            const dist = "${{ inputs.tenx_dist }}";
+            if (dist === "Edge") {
+              core.setFailed("The Edge dist is retired. It built the jpackage JIT image (tag suffix -jit); install.sh no longer accepts --flavor edge. Use Runtime.")
+            } else if (dist !== "Runtime" && dist !== "Native") {
+              core.setFailed("Only the Runtime dist is supported (Native is accepted as its old name)")
             }
 
       - name: Prepare variables
@@ -129,18 +136,14 @@ jobs:
           echo "docker_repo=${{ vars.GHCR_REPO_NAME }}" >> "$GITHUB_OUTPUT"
           echo "dockerhub_repo=docker.io/${{ vars.DOCKERHUB_REPO_NAME }}" >> "$GITHUB_OUTPUT"
 
+          # The tag SUFFIX stays "-native". It is part of a published image
+          # name, not a flag: 222 filebeat-10x tags carry it, the Receiver docs
+          # pin exact tags, and charts/filebeat/values.yaml selects on it.
+          # Renaming the flavor does not rename images already pulled.
           if [ "${{ inputs.forwarder_type }}" != "Fluent-Bit-Debug" ] && [ "${{ inputs.forwarder_type }}" != "Filebeat-Debug" ]; then
-            if [ "${{ inputs.tenx_dist }}" == "Edge" ]; then
-              echo "version_tag=${{inputs.release_version}}-jit" >> "$GITHUB_OUTPUT"
-            elif [ "${{ inputs.tenx_dist }}" == "Native" ]; then
-              echo "version_tag=${{inputs.release_version}}-native" >> "$GITHUB_OUTPUT"
-            fi
+            echo "version_tag=${{inputs.release_version}}-native" >> "$GITHUB_OUTPUT"
           else
-            if [ "${{ inputs.tenx_dist }}" == "Edge" ]; then
-              echo "version_tag=${{inputs.release_version}}-jit-debug" >> "$GITHUB_OUTPUT"
-            elif [ "${{ inputs.tenx_dist }}" == "Native" ]; then
-              echo "version_tag=${{inputs.release_version}}-native-debug" >> "$GITHUB_OUTPUT"
-            fi
+            echo "version_tag=${{inputs.release_version}}-native-debug" >> "$GITHUB_OUTPUT"
           fi
 
           IMAGES=""
@@ -212,7 +215,7 @@ jobs:
           provenance: false
           build-args: |
             VERSION=${{inputs.release_version}}
-            FLAVOR=${{inputs.tenx_dist}}
+            FLAVOR=runtime
             LICENSE_JWT=${{ env.LICENSE_JWT }}
           tags: ${{ steps.docker-meta.outputs.tags }}
 
@@ -268,7 +271,7 @@ jobs:
           provenance: false
           build-args: |
             VERSION=${{inputs.release_version}}
-            FLAVOR=${{inputs.tenx_dist}}
+            FLAVOR=runtime
             LICENSE_JWT=${{ env.LICENSE_JWT }}
           tags: ${{ steps.docker-meta.outputs.tags }}
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ an engine for dynamically optimizing execution with the goal improving performan
 
 ## Edge
 
-Docker image of a lightweight Debian (bookworm-slim) container with [Log10x Edge](https://doc.log10x.com/engine/flavors/#edge) as a GraalVM native binary.
+Docker image of a lightweight Debian (bookworm-slim) container with the [Log10x runtime](https://doc.log10x.com/engine/flavors/) as a GraalVM native binary.
 
 Designed for [sidecar deployments](https://doc.log10x.com/engine/launcher/sidecar/) alongside log forwarders (Fluentd, Fluent Bit, OTel Collector), providing real-time log/trace optimization at the edge with minimal resource footprint.
 
@@ -15,13 +15,13 @@ Visit our [Docker deployment](https://doc.log10x.com/install/docker/) documentat
 
 ## Pipeline
 
-Docker image of a Red Hat (ubi8) container with [Log10x Cloud](https://doc.log10x.com/engine/flavors/#cloud)
+Docker image of a Red Hat (ubi8) container with the [Log10x compiler](https://doc.log10x.com/engine/flavors/)
 
 Visit our [Docker deployment](https://doc.log10x.com/install/docker/) documentation for more info about using this image.
 
 ## Quarkus
 
-Docker image of a [Quarkus](https://quarkus.io/) server capable of invoking [Log10x pipelines](https://doc.log10x.com/engine/pipeline/) on demand with [Log10x Cloud](https://doc.log10x.com/engine/flavors/#cloud) capabilities.
+Docker image of a [Quarkus](https://quarkus.io/) server capable of invoking [Log10x pipelines](https://doc.log10x.com/engine/pipeline/) on demand with the [Log10x compiler](https://doc.log10x.com/engine/flavors/) capabilities.
 
 Visit our [Docker deployment](https://doc.log10x.com/install/docker/) documentation for more info about using this image.
 

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -11,9 +11,11 @@ ARG VERSION
 #
 RUN apt-get update && apt-get install -y curl
 
-# Install 10x native edge binary
+# Install the 10x runtime: the native binary (reporter, receiver, retriever,
+# MCP, CLI). 'runtime' is the flavor flag; the install prefix it produces is
+# /opt/tenx-edge, named for the package id -- see pipeline-releases/FLAVORS.md.
 #
-RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor native --no-env-setup
+RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor runtime --no-env-setup
 
 FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:bookworm-slim
 

--- a/edge/README.md
+++ b/edge/README.md
@@ -1,6 +1,6 @@
 # 🔟❎ Edge
 
-Docker image of a lightweight Debian (bookworm-slim) container with [Log10x Edge](https://doc.log10x.com/engine/flavors/#edge) as a GraalVM native binary.
+Docker image of a lightweight Debian (bookworm-slim) container with the [Log10x runtime](https://doc.log10x.com/engine/flavors/) as a GraalVM native binary.
 
 ## Quick start
 

--- a/fwd/filebeat/Dockerfile
+++ b/fwd/filebeat/Dockerfile
@@ -8,12 +8,17 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} ubuntu:20.04 AS tenx-builder
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG VERSION
-ARG FLAVOR="edge"
+ARG FLAVOR="runtime"
 
-# Validate that FLAVOR is either edge/native, cloud isn't supported for forwarder builds
+# Only the runtime flavor is supported for forwarder builds. The compiler
+# flavor is a .deb/.rpm with a bundled JRE and installs to /opt/tenx-cloud,
+# which is not the prefix this image bakes into TENX_HOME below.
+#
+# 'native' is the old spelling of 'runtime' and still resolves; 'edge' named
+# the retired jpackage JIT build and is rejected by install.sh itself.
 RUN VALIDATE_FLAVOR=$(echo "${FLAVOR}" | tr '[:upper:]' '[:lower:]') && \
-    if [ "$VALIDATE_FLAVOR" != "edge" ] && [ "$VALIDATE_FLAVOR" != "native" ]; then \
-    echo "Invalid flavor: ${FLAVOR}. Allowed values are: Edge, Native" >&2; \
+    if [ "$VALIDATE_FLAVOR" != "runtime" ] && [ "$VALIDATE_FLAVOR" != "native" ]; then \
+    echo "Invalid flavor: ${FLAVOR}. Allowed values are: Runtime" >&2; \
     exit 1; \
 fi
 
@@ -44,6 +49,9 @@ ARG LICENSE_JWT
 
 # Manually setting up 10x environment variables
 #
+# /opt/tenx-edge is the install prefix for the RUNTIME flavor. The prefix is
+# named for the package id, not the flavor, and it does not change with the
+# rename -- see pipeline-releases/FLAVORS.md.
 ENV TENX_HOME=/opt/tenx-edge
 ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules

--- a/fwd/filebeat/debug/Dockerfile
+++ b/fwd/filebeat/debug/Dockerfile
@@ -8,12 +8,17 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} ubuntu:20.04 AS tenx-builder
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG VERSION
-ARG FLAVOR="edge"
+ARG FLAVOR="runtime"
 
-# Validate that FLAVOR is either edge/native, cloud isn't supported for forwarder builds
+# Only the runtime flavor is supported for forwarder builds. The compiler
+# flavor is a .deb/.rpm with a bundled JRE and installs to /opt/tenx-cloud,
+# which is not the prefix this image bakes into TENX_HOME below.
+#
+# 'native' is the old spelling of 'runtime' and still resolves; 'edge' named
+# the retired jpackage JIT build and is rejected by install.sh itself.
 RUN VALIDATE_FLAVOR=$(echo "${FLAVOR}" | tr '[:upper:]' '[:lower:]') && \
-    if [ "$VALIDATE_FLAVOR" != "edge" ] && [ "$VALIDATE_FLAVOR" != "native" ]; then \
-    echo "Invalid flavor: ${FLAVOR}. Allowed values are: Edge, Native" >&2; \
+    if [ "$VALIDATE_FLAVOR" != "runtime" ] && [ "$VALIDATE_FLAVOR" != "native" ]; then \
+    echo "Invalid flavor: ${FLAVOR}. Allowed values are: Runtime" >&2; \
     exit 1; \
 fi
 
@@ -44,6 +49,9 @@ ARG LICENSE_JWT
 
 # Manually setting up 10x environment variables
 #
+# /opt/tenx-edge is the install prefix for the RUNTIME flavor. The prefix is
+# named for the package id, not the flavor, and it does not change with the
+# rename -- see pipeline-releases/FLAVORS.md.
 ENV TENX_HOME=/opt/tenx-edge
 ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules

--- a/fwd/fluent-bit/Dockerfile
+++ b/fwd/fluent-bit/Dockerfile
@@ -8,12 +8,17 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:bookworm-slim AS tenx-build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG VERSION
-ARG FLAVOR="edge"
+ARG FLAVOR="runtime"
 
-# Validate that FLAVOR is either edge/native, cloud isn't supported for forwarder builds
+# Only the runtime flavor is supported for forwarder builds. The compiler
+# flavor is a .deb/.rpm with a bundled JRE and installs to /opt/tenx-cloud,
+# which is not the prefix this image bakes into TENX_HOME below.
+#
+# 'native' is the old spelling of 'runtime' and still resolves; 'edge' named
+# the retired jpackage JIT build and is rejected by install.sh itself.
 RUN VALIDATE_FLAVOR=$(echo "${FLAVOR}" | tr '[:upper:]' '[:lower:]') && \
-    if [ "$VALIDATE_FLAVOR" != "edge" ] && [ "$VALIDATE_FLAVOR" != "native" ]; then \
-    echo "Invalid flavor: ${FLAVOR}. Allowed values are: Edge, Native" >&2; \
+    if [ "$VALIDATE_FLAVOR" != "runtime" ] && [ "$VALIDATE_FLAVOR" != "native" ]; then \
+    echo "Invalid flavor: ${FLAVOR}. Allowed values are: Runtime" >&2; \
     exit 1; \
 fi
 
@@ -45,6 +50,9 @@ ARG LICENSE_JWT
 
 # Manually setting up 10x environment variables
 #
+# /opt/tenx-edge is the install prefix for the RUNTIME flavor. The prefix is
+# named for the package id, not the flavor, and it does not change with the
+# rename -- see pipeline-releases/FLAVORS.md.
 ENV TENX_HOME=/opt/tenx-edge
 ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules

--- a/fwd/fluent-bit/debug/Dockerfile
+++ b/fwd/fluent-bit/debug/Dockerfile
@@ -8,12 +8,17 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:bookworm-slim AS tenx-build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG VERSION
-ARG FLAVOR="edge"
+ARG FLAVOR="runtime"
 
-# Validate that FLAVOR is either edge/native, cloud isn't supported for forwarder builds
+# Only the runtime flavor is supported for forwarder builds. The compiler
+# flavor is a .deb/.rpm with a bundled JRE and installs to /opt/tenx-cloud,
+# which is not the prefix this image bakes into TENX_HOME below.
+#
+# 'native' is the old spelling of 'runtime' and still resolves; 'edge' named
+# the retired jpackage JIT build and is rejected by install.sh itself.
 RUN VALIDATE_FLAVOR=$(echo "${FLAVOR}" | tr '[:upper:]' '[:lower:]') && \
-    if [ "$VALIDATE_FLAVOR" != "edge" ] && [ "$VALIDATE_FLAVOR" != "native" ]; then \
-    echo "Invalid flavor: ${FLAVOR}. Allowed values are: Edge, Native" >&2; \
+    if [ "$VALIDATE_FLAVOR" != "runtime" ] && [ "$VALIDATE_FLAVOR" != "native" ]; then \
+    echo "Invalid flavor: ${FLAVOR}. Allowed values are: Runtime" >&2; \
     exit 1; \
 fi
 
@@ -45,6 +50,9 @@ ARG LICENSE_JWT
 
 # Manually setting up 10x environment variables
 #
+# /opt/tenx-edge is the install prefix for the RUNTIME flavor. The prefix is
+# named for the package id, not the flavor, and it does not change with the
+# rename -- see pipeline-releases/FLAVORS.md.
 ENV TENX_HOME=/opt/tenx-edge
 ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules

--- a/fwd/fluentd/Dockerfile
+++ b/fwd/fluentd/Dockerfile
@@ -8,12 +8,17 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:bookworm-slim AS tenx-build
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG VERSION
-ARG FLAVOR="edge"
+ARG FLAVOR="runtime"
 
-# Validate that FLAVOR is either edge/native, cloud isn't supported for forwarder builds
+# Only the runtime flavor is supported for forwarder builds. The compiler
+# flavor is a .deb/.rpm with a bundled JRE and installs to /opt/tenx-cloud,
+# which is not the prefix this image bakes into TENX_HOME below.
+#
+# 'native' is the old spelling of 'runtime' and still resolves; 'edge' named
+# the retired jpackage JIT build and is rejected by install.sh itself.
 RUN VALIDATE_FLAVOR=$(echo "${FLAVOR}" | tr '[:upper:]' '[:lower:]') && \
-    if [ "$VALIDATE_FLAVOR" != "edge" ] && [ "$VALIDATE_FLAVOR" != "native" ]; then \
-    echo "Invalid flavor: ${FLAVOR}. Allowed values are: Edge, Native" >&2; \
+    if [ "$VALIDATE_FLAVOR" != "runtime" ] && [ "$VALIDATE_FLAVOR" != "native" ]; then \
+    echo "Invalid flavor: ${FLAVOR}. Allowed values are: Runtime" >&2; \
     exit 1; \
 fi
 
@@ -47,6 +52,9 @@ ARG LICENSE_JWT
 
 # Manually setting up 10x environment variables
 #
+# /opt/tenx-edge is the install prefix for the RUNTIME flavor. The prefix is
+# named for the package id, not the flavor, and it does not change with the
+# rename -- see pipeline-releases/FLAVORS.md.
 ENV TENX_HOME=/opt/tenx-edge
 ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -6,7 +6,8 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi8/ub
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG VERSION
-ARG FLAVOR="cloud"
+# The flavor FLAG passed to install.sh.
+ARG FLAVOR="compiler"
 
 # Install curl, needed for 10x install script
 #
@@ -30,7 +31,11 @@ LABEL com.log10x.license.url="https://log10x.com/pricing"
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ARG FLAVOR="cloud"
+# PACKAGE_ID is the install prefix and binary name that the compiler flavor's
+# .deb/.rpm creates. It is NOT the flavor flag above, and it does not change
+# with the flavor rename -- see pipeline-releases/FLAVORS.md. Change these two
+# only together.
+ARG PACKAGE_ID="cloud"
 ARG LICENSE_JWT
 
 # Install binutils (strings) + file (executable scanner), needed for 10x 'compile'
@@ -62,9 +67,9 @@ RUN mkdir -p /var/log/tenx && chmod 777 /var/log/tenx
 
 # Manually setting up 10x environment variables
 #
-ENV TENX_HOME=/opt/tenx-${FLAVOR}
-ENV TENX_BIN=/opt/tenx-${FLAVOR}/bin/tenx-${FLAVOR}
-ENV TENX_MODULES=/opt/tenx-${FLAVOR}/lib/app/modules
+ENV TENX_HOME=/opt/tenx-${PACKAGE_ID}
+ENV TENX_BIN=/opt/tenx-${PACKAGE_ID}/bin/tenx-${PACKAGE_ID}
+ENV TENX_MODULES=/opt/tenx-${PACKAGE_ID}/lib/app/modules
 ENV TENX_CONFIG=/etc/tenx/config
 ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
 ENV TENX_LICENSE_KEY=${LICENSE_JWT}

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -1,6 +1,6 @@
 # 🔟❎ Pipeline
 
-Docker image of a Red Hat (ubi8) container with [Log10x Cloud](https://doc.log10x.com/engine/flavors/#cloud)
+Docker image of a Red Hat (ubi8) container with the [Log10x compiler](https://doc.log10x.com/engine/flavors/)
 
 ## Quick start
 
@@ -13,7 +13,7 @@ The image ships with a built-in limited license. For the full engine, download y
 
 ## Under the hood
 
-This image is bundled with all the tools that are required by Log10x cloud to work:
+This image is bundled with all the tools that are required by the Log10x compiler to work:
 
 - binutils and python39, which are needed for the [compile](https://doc.log10x.com/compile/) pipeline
 - [Fluentbit](https://fluentbit.io/), allowing pipeline output to be emitted to your destination of choice.

--- a/quarkus/README.md
+++ b/quarkus/README.md
@@ -1,6 +1,6 @@
 # 🔟❎ Quarkus
 
-Docker image of a [Quarkus](https://quarkus.io/) server capable of invoking [Log10x pipelines](https://doc.log10x.com/engine/pipeline/) on demand with [Log10x Cloud](https://doc.log10x.com/engine/flavors/#cloud) capabilities.
+Docker image of a [Quarkus](https://quarkus.io/) server capable of invoking [Log10x pipelines](https://doc.log10x.com/engine/pipeline/) on demand with the [Log10x compiler](https://doc.log10x.com/engine/flavors/) capabilities.
 
 ## Quick start
 
@@ -15,7 +15,7 @@ The image ships with a built-in limited license. For the full engine, download y
 
 This image is built on [Quarkus](https://quarkus.io/), the Supersonic Subatomic Java Framework.
 
-Additionally, this image is bundled with all the tools that are required by Log10x cloud to work:
+Additionally, this image is bundled with all the tools that are required by the Log10x compiler to work:
 
 - binutils and python39, which are needed for the [compile](https://doc.log10x.com/compile/) pipeline
 - [Fluentbit](https://fluentbit.io/), allowing pipeline output to be emitted to your destination of choice.


### PR DESCRIPTION
## What

Follows **log-10x/pipeline-releases#6**. Every Dockerfile here installs 10x by piping `install.sh` into bash, so the flag values that script accepts are this repo's build contract.

```
--flavor native  ->  --flavor runtime      edge/Dockerfile, fwd/*/Dockerfile
--flavor cloud   ->  --flavor compiler     pipeline/Dockerfile
```

## Merge order matters

`install.sh` is fetched from `pipeline-releases` **main**, unpinned, at build time:

```dockerfile
RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup
```

Merging this before pipeline-releases#6 makes every build here fail with `Invalid flavor: runtime`. Merge that one first.

## The JIT forwarder builds are deleted

Five jobs go: `filebeat-jit`, `filebeat-debug-jit`, `fluent-bit-jit`, `fluent-bit-debug-jit`, `fluentd-jit`. They passed `tenx_dist: Edge`, which became `--flavor edge`, which installed the jpackage `.deb`. That flavor is gone, so those jobs could only fail. The surviving jobs lose their `-native` suffix in the job name because there is nothing left to distinguish them from.

`publish_latest: true` is still set on exactly one job.

## What deliberately does NOT change

- **`/opt/tenx-edge` and `/opt/tenx-cloud`.** They are `ENV TENX_HOME` / `TENX_BIN` in images already published, and the prefix is created by the package, not by us. `pipeline/Dockerfile` now says this in the code rather than in a comment somewhere else: `ARG FLAVOR` is the flag, `ARG PACKAGE_ID` is the prefix, and they are separate args because they are separate things.
- **The `-native` tag suffix.** 222 `filebeat-10x` tags carry it, the Receiver docs pin exact tags, and `elastic-helm-charts` `values.yaml` selects on it. Renaming a flavor does not rename images that are already pulled.
- **Existing `-jit` tags.** Untouched. No new ones are cut.

`tenx_dist` accepts `Runtime`, still accepts `Native` as its old name so an in-flight dispatch does not fail on the rename, and rejects `Edge` with the reason, rather than letting the build get as far as `install.sh` and fail there with less context.

## Verified

Built the edge image against the new `install.sh` (local copy, since main does not have it yet):

```
$ docker run --rm --entrypoint sh tenx-rename-edge-test -c 'ls -l /opt/tenx-edge/bin/'
tenx      -> /opt/tenx-edge/bin/tenx-edge
tenx-edge -> /opt/tenx-edge/bin/tenx-edge-1.1.37-amd64-native
-rwxr-xr-x  77794576  tenx-edge-1.1.37-amd64-native

$ docker run --rm tenx-rename-edge-test --version
10x engine v1.1.37, flavor: 'edge'
```

Same two symlinks, same prefix, same names as main produces. The compiler flavor installs to `/opt/tenx-cloud/bin/tenx-cloud` and reports `flavor: 'cloud'`.

All 12 workflow files parse under `yaml.safe_load`.

## Not done here

The engine binary self-reports `flavor: 'edge'` / `'cloud'`. That string is in `log-10x/engine`.
