### PR TITLE
fix(fluent-bit): build the native image, which has never built

### DIFF
--- a/fwd/fluent-bit/Dockerfile
+++ b/fwd/fluent-bit/Dockerfile
@@ -5,6 +5,9 @@
 #
 FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:bookworm-slim AS tenx-builder
 
+# Created here because the fluent-bit runtime stage has no coreutils (see below).
+RUN mkdir -p /var/log/tenx && chmod 777 /var/log/tenx
+
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG VERSION
@@ -104,5 +107,9 @@ COPY --from=tenx-builder $TENX_HOME $TENX_HOME
 # with the file appender only the startup banner reaches stdout, so `kubectl
 # logs` shows a healthy-looking pod while every WARN, ERROR and stack trace goes
 # to a file nobody reads. Set TENX_LOG_APPENDER=tenxFileAppender to opt back in.
-RUN mkdir -p /var/log/tenx && chmod 777 /var/log/tenx
+# fluent/fluent-bit has no coreutils, so `mkdir` does not exist in this stage:
+# `RUN mkdir -p /var/log/tenx` fails with `/bin/sh: 1: mkdir: not found`, which is
+# why no native fluent-bit image has ever built. Create it in the builder, which is
+# debian-based, and copy the directory in.
+COPY --from=tenx-builder --chmod=777 /var/log/tenx /var/log/tenx
 ENV TENX_LOG_APPENDER=tenxConsoleAppender


### PR DESCRIPTION
`fwd/fluent-bit/Dockerfile` runs `mkdir -p /var/log/tenx` in the final stage, which is `FROM fluent/fluent-bit:4.1.1`. That image ships no coreutils, so it fails with `/bin/sh: 1: mkdir: not found`.

Introduced by #11, which added the line to every forwarder. Filebeat survived because the Elastic base has `mkdir`.

**The registry shows the consequence:** `log10x/fluent-bit-10x` has only `1.0.21-jit`. No native fluent-bit image has ever been published. Today's 1.1.38 forwarder publish failed on exactly this, for both amd64 and aarch64.

Creates the directory in the debian-based `tenx-builder` stage and copies it in with `--chmod=777`.

**Verified by running the build that had never succeeded** — exit 0 — and against the resulting image: `/var/log/tenx` exists and is writable, and `/opt/tenx-edge/bin/tenx --version` reports `10x engine v1.1.38, flavor: 'runtime'`.