### PR TITLE
fix(images): own the installed 10x tree as root, not uid 1001

### DIFF
--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -51,11 +51,20 @@ ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 #
 ENV TENX_LOG_APPENDER=tenxConsoleAppender
 
-# Copy 10x from builder
+# Copy 10x from builder, forcing root ownership.
 #
-COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
-COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
-COPY --from=tenx-builder $TENX_HOME $TENX_HOME
+# --chown=0:0 is load-bearing. The release tarballs on
+# log-10x/pipeline-releases are packed by a GitHub Actions runner, so every
+# member carries uid/gid 1001 ("runner"), install.sh unpacks them with
+# `tar -xzf` as root, and GNU tar restores the archived owner when it runs as
+# root. A plain `COPY --from` then preserves 1001:1001 into the final image,
+# which means the engine binary and its config are owned by whatever local
+# account happens to hold uid 1001. Filebeat's strict-perms check rejects that
+# outright; see fwd/filebeat/Dockerfile for the measured failure.
+#
+COPY --chown=0:0 --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
+COPY --chown=0:0 --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
+COPY --chown=0:0 --from=tenx-builder $TENX_HOME $TENX_HOME
 
 # Give permissions to the config
 #

--- a/fwd/filebeat/Dockerfile
+++ b/fwd/filebeat/Dockerfile
@@ -76,11 +76,43 @@ USER root
 #
 RUN sed -i '0,/exec filebeat "$@"/s//exec filebeat "$@" 2\>\&1 | $TENX_BIN run $TENX_RUN_ARGS/' /usr/local/bin/docker-entrypoint
 
-# Copy 10x from builder
+# Copy 10x from builder, forcing root ownership.
 #
-COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
-COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
-COPY --from=tenx-builder $TENX_HOME $TENX_HOME
+# --chown=0:0 is load-bearing. The release tarballs on
+# log-10x/pipeline-releases are packed by a GitHub Actions runner, so every
+# member carries uid/gid 1001 ("runner"):
+#
+#   $ tar --numeric-owner -tvzf tenx-modules-1.1.38.tar.gz | head -1
+#   -rw-r--r--  0 1001 1001  1074 LICENSE
+#
+# install.sh unpacks them with `tar -xzf` as root, and GNU tar restores the
+# archived owner when it runs as root, so the whole installed tree lands as
+# 1001:1001. A plain `COPY --from` preserves that into the final image.
+#
+# Filebeat then refuses to load its own config files, because libbeat's
+# strict-perms check requires every config file to be owned by root or by the
+# effective uid. Measured on this image built without --chown, run as uid 0,
+# which is what the chart uses (daemonset.securityContext.runAsUser: 0):
+#
+#   Exiting: Failed to start crawler: starting input failed: error while
+#   initializing input: failed in processor.javascript: config file
+#   (".../input/forwarder/filebeat/script/tenx-receive.js") must be owned by
+#   the user identifier (uid=0) or root
+#   exit 1
+#
+# The chart loads two files out of this tree: the script processor above and
+# `conf/tenxNix.yml` via filebeat.config.inputs, so both trip the check.
+#
+# uid 0 is the right owner rather than 1000/filebeat: libbeat accepts a
+# root-owned config for ANY effective uid, so this works whether the pod runs
+# as root or as the image's default filebeat user. The alternative fix,
+# passing -strict.perms=false in the chart, disables a security check to paper
+# over our own packaging, and would leave the engine binary owned by whatever
+# local account happens to hold uid 1001.
+#
+COPY --chown=0:0 --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
+COPY --chown=0:0 --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
+COPY --chown=0:0 --from=tenx-builder $TENX_HOME $TENX_HOME
 
 # Switch back tothe filebeat user, same as original image
 #

--- a/fwd/filebeat/debug/Dockerfile
+++ b/fwd/filebeat/debug/Dockerfile
@@ -80,11 +80,43 @@ RUN mkdir -p /etc/tenx/debug
 #
 RUN sed -i '0,/exec filebeat "$@"/s//exec filebeat "$@" 2\>\&1 | tee \/etc\/tenx\/debug\/raw_filebeat.log | $TENX_BIN run $TENX_RUN_ARGS/' /usr/local/bin/docker-entrypoint
 
-# Copy 10x from builder
+# Copy 10x from builder, forcing root ownership.
 #
-COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
-COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
-COPY --from=tenx-builder $TENX_HOME $TENX_HOME
+# --chown=0:0 is load-bearing. The release tarballs on
+# log-10x/pipeline-releases are packed by a GitHub Actions runner, so every
+# member carries uid/gid 1001 ("runner"):
+#
+#   $ tar --numeric-owner -tvzf tenx-modules-1.1.38.tar.gz | head -1
+#   -rw-r--r--  0 1001 1001  1074 LICENSE
+#
+# install.sh unpacks them with `tar -xzf` as root, and GNU tar restores the
+# archived owner when it runs as root, so the whole installed tree lands as
+# 1001:1001. A plain `COPY --from` preserves that into the final image.
+#
+# Filebeat then refuses to load its own config files, because libbeat's
+# strict-perms check requires every config file to be owned by root or by the
+# effective uid. Measured on this image built without --chown, run as uid 0,
+# which is what the chart uses (daemonset.securityContext.runAsUser: 0):
+#
+#   Exiting: Failed to start crawler: starting input failed: error while
+#   initializing input: failed in processor.javascript: config file
+#   (".../input/forwarder/filebeat/script/tenx-receive.js") must be owned by
+#   the user identifier (uid=0) or root
+#   exit 1
+#
+# The chart loads two files out of this tree: the script processor above and
+# `conf/tenxNix.yml` via filebeat.config.inputs, so both trip the check.
+#
+# uid 0 is the right owner rather than 1000/filebeat: libbeat accepts a
+# root-owned config for ANY effective uid, so this works whether the pod runs
+# as root or as the image's default filebeat user. The alternative fix,
+# passing -strict.perms=false in the chart, disables a security check to paper
+# over our own packaging, and would leave the engine binary owned by whatever
+# local account happens to hold uid 1001.
+#
+COPY --chown=0:0 --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
+COPY --chown=0:0 --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
+COPY --chown=0:0 --from=tenx-builder $TENX_HOME $TENX_HOME
 
 # Switch back tothe filebeat user, same as original image
 #

--- a/fwd/fluent-bit/Dockerfile
+++ b/fwd/fluent-bit/Dockerfile
@@ -78,11 +78,20 @@ ENV TENX_CONFIG=/etc/tenx/config
 #
 COPY --from=tenx-builder /bin/dash /bin/sh
 
-# Copy 10x from builder
+# Copy 10x from builder, forcing root ownership.
 #
-COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
-COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
-COPY --from=tenx-builder $TENX_HOME $TENX_HOME
+# --chown=0:0 is load-bearing. The release tarballs on
+# log-10x/pipeline-releases are packed by a GitHub Actions runner, so every
+# member carries uid/gid 1001 ("runner"), install.sh unpacks them with
+# `tar -xzf` as root, and GNU tar restores the archived owner when it runs as
+# root. A plain `COPY --from` then preserves 1001:1001 into the final image,
+# which means the engine binary and its config are owned by whatever local
+# account happens to hold uid 1001. Filebeat's strict-perms check rejects that
+# outright; see fwd/filebeat/Dockerfile for the measured failure.
+#
+COPY --chown=0:0 --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
+COPY --chown=0:0 --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
+COPY --chown=0:0 --from=tenx-builder $TENX_HOME $TENX_HOME
 
 # Create the engine's log directory and default its logs to stdout.
 #

--- a/fwd/fluent-bit/debug/Dockerfile
+++ b/fwd/fluent-bit/debug/Dockerfile
@@ -64,11 +64,20 @@ ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 #
 ENV TENX_CONFIG=/etc/tenx/config
 
-# Copy 10x from builder
+# Copy 10x from builder, forcing root ownership.
 #
-COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
-COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
-COPY --from=tenx-builder $TENX_HOME $TENX_HOME
+# --chown=0:0 is load-bearing. The release tarballs on
+# log-10x/pipeline-releases are packed by a GitHub Actions runner, so every
+# member carries uid/gid 1001 ("runner"), install.sh unpacks them with
+# `tar -xzf` as root, and GNU tar restores the archived owner when it runs as
+# root. A plain `COPY --from` then preserves 1001:1001 into the final image,
+# which means the engine binary and its config are owned by whatever local
+# account happens to hold uid 1001. Filebeat's strict-perms check rejects that
+# outright; see fwd/filebeat/Dockerfile for the measured failure.
+#
+COPY --chown=0:0 --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
+COPY --chown=0:0 --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
+COPY --chown=0:0 --from=tenx-builder $TENX_HOME $TENX_HOME
 
 # Adding an entrypoint as the debug image doesn't do that
 #

--- a/fwd/fluentd/Dockerfile
+++ b/fwd/fluentd/Dockerfile
@@ -66,11 +66,20 @@ ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 #
 ENV TENX_CONFIG=/etc/tenx/config
 
-# Copy 10x from builder
+# Copy 10x from builder, forcing root ownership.
 #
-COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
-COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
-COPY --from=tenx-builder $TENX_HOME $TENX_HOME
+# --chown=0:0 is load-bearing. The release tarballs on
+# log-10x/pipeline-releases are packed by a GitHub Actions runner, so every
+# member carries uid/gid 1001 ("runner"), install.sh unpacks them with
+# `tar -xzf` as root, and GNU tar restores the archived owner when it runs as
+# root. A plain `COPY --from` then preserves 1001:1001 into the final image,
+# which means the engine binary and its config are owned by whatever local
+# account happens to hold uid 1001. Filebeat's strict-perms check rejects that
+# outright; see fwd/filebeat/Dockerfile for the measured failure.
+#
+COPY --chown=0:0 --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
+COPY --chown=0:0 --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
+COPY --chown=0:0 --from=tenx-builder $TENX_HOME $TENX_HOME
 
 # Create the engine's log directory and default its logs to stdout.
 #

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -78,11 +78,20 @@ ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 #
 ENV TENX_LOG_APPENDER=tenxConsoleAppender
 
-# Copy 10x from builder
+# Copy 10x from builder, forcing root ownership.
 #
-COPY --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
-COPY --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
-COPY --from=tenx-builder $TENX_HOME $TENX_HOME
+# --chown=0:0 is load-bearing. The release tarballs on
+# log-10x/pipeline-releases are packed by a GitHub Actions runner, so every
+# member carries uid/gid 1001 ("runner"), install.sh unpacks them with
+# `tar -xzf` as root, and GNU tar restores the archived owner when it runs as
+# root. A plain `COPY --from` then preserves 1001:1001 into the final image,
+# which means the engine binary and its config are owned by whatever local
+# account happens to hold uid 1001. Filebeat's strict-perms check rejects that
+# outright; see fwd/filebeat/Dockerfile for the measured failure.
+#
+COPY --chown=0:0 --from=tenx-builder $TENX_SYMBOLS_PATH $TENX_SYMBOLS_PATH
+COPY --chown=0:0 --from=tenx-builder $TENX_CONFIG $TENX_CONFIG
+COPY --chown=0:0 --from=tenx-builder $TENX_HOME $TENX_HOME
 
 # Give permissions to the config
 #


### PR DESCRIPTION
## The defect

Every file installed from the `pipeline-releases` tarballs lands in our images owned by uid/gid **1001**, and Filebeat refuses to load its own config files as a result. The chart's DaemonSet dies at startup.

Measured on `fwd/filebeat/Dockerfile` built from `main` at 1.1.38:

```
$ docker run --rm --entrypoint sh tenxtest/filebeat-before:1.1.38 -c 'ls -ln .../filebeat/conf .../filebeat/script'
-rw-r--r-- 1 1001 1001 906 tenxNix.yml
-rw-r--r-- 1 1001 1001 917 tenxWin.yml
-rw-r--r-- 1 1001 1001 583 tenx-receive.js
-rw-r--r-- 1 1001 1001 480 tenx-report.js
```

Run as uid 0, which is what the chart uses (`daemonset.securityContext.runAsUser: 0`), with the chart's own `filebeat.yml` shape and no `-strict.perms=false`:

```
$ docker run --rm --user 0:0 --entrypoint filebeat tenxtest/probe-before:1.1.38 -e -E http.enabled=true
Exiting: Failed to start crawler: starting input failed: error while initializing
input: failed in processor.javascript: config file
(".../input/forwarder/filebeat/script/tenx-receive.js") must be owned by the user
identifier (uid=0) or root
EXIT=1
```

## Why the files are 1001

Not a Dockerfile bug in origin, a packaging bug that the Dockerfile propagates.

1. The release tarballs are packed by a GitHub Actions runner, so every member carries the runner's uid/gid:

```
$ tar --numeric-owner -tvzf tenx-modules-1.1.38.tar.gz | head -1
-rw-r--r--  0 1001 1001  1074 Aug  1 22:29 LICENSE
```

2. `install.sh` unpacks with `tar -xzf "$TEMP_DIR/$MODULES_FILE" -C "$TENX_MODULES"` (lines 610 and 631). GNU tar restores the archived owner when it runs as root, which it does inside the builder stage, so the installed tree is 1001:1001.
3. A plain `COPY --from=tenx-builder` preserves that ownership into the final image.

Only the directories `install.sh` creates with `mkdir -p` come out as root, which is why `/opt/tenx-edge` looks fine while everything under it does not.

## The fix

`--chown=0:0` on the three `COPY --from=tenx-builder` lines, in every image that copies the installed tree, not only filebeat. The other forwarders and `edge`/`pipeline` ship the same 1001-owned tree; they just have no check that catches it, and `edge`/`pipeline` paper over the config half with `chmod -R 777 $TENX_CONFIG`.

uid 0 rather than 1000/filebeat because libbeat accepts a **root-owned** config for any effective uid, so one ownership works whether the pod runs as root or as the image's default `filebeat` user.

**Why not `-strict.perms=false` in the chart.** That disables a security check to paper over our own packaging, and it does not address the real problem underneath: the engine binary and its entire config tree are owned by whatever local account happens to hold uid 1001 on the host or in the image. On a bare-metal `install.sh` run that is a real user who can then rewrite a binary root executes.

## Proof

Same image, same config, same licence, only `--chown` differing. Real Filebeat, real engine, real entrypoint (`filebeat | tenx run`), run as uid 0, **no `-strict.perms=false` anywhere**.

| | before | after |
|---|---|---|
| `find /opt/tenx-edge /etc/tenx ! -uid 0 \| wc -l` | 882 | **0** |
| filebeat crawler | `Exiting: Failed to start crawler ... must be owned by ...` | `Loading and starting Inputs completed. Enabled inputs: 2` |
| container, real entrypoint | **exit 1** after 6s | still up when the 45s window closed (`exit 124` from `timeout`) |
| `grep -c "must be owned"` | 1 | **0** |

The engine comes all the way up after the fix:

```
📥 Reading events from Filebeat via stdin
🚦 Applying rate regulator to: filebeat
📝 Writing TenXObject field: 'fullText("tenx_hash")' → /tmp/tenx_filebeat.sock
[INFO] ResourceReloadUnit - resource reload: starting with 3 watched path(s); pollInterval=10s
```

No regression for the images that end on a non-root USER. `edge-10x` rebuilt and run as its default `tenxuser` (uid 1000) against the now root-owned tree:

```
$ docker run --rm tenxtest/edge-after:1.1.38 --version
10x engine v1.1.38, flavor: 'runtime'
```

All seven images rebuilt at 1.1.38 and counted, zero non-root entries under the installed trees in every one:

| image | build | non-root entries under `/opt/tenx-*` + `/etc/tenx` |
|---|---|---|
| `filebeat-10x` | exit 0 | 0 (was 882) |
| `filebeat-10x` debug | exit 0 | 0 |
| `fluent-bit-10x` | exit 0 | 0 of 893 entries |
| `fluent-bit-10x` debug | exit 0 | 0 of 893 entries |
| `fluentd-10x` | exit 0 | 0 |
| `edge-10x` | exit 0 | 0 |
| `pipeline-10x` | exit 0 | 0 of 1248 entries |

fluent-bit and pipeline have no `find` in the image, so those were counted off `docker export | tar -tv`.

## Follow-up, not in this PR

The upstream cause is `install.sh` in `log-10x/pipeline-releases`, which should extract with `tar --no-same-owner`. That would fix bare-metal installs too, where today `sudo ./install.sh` leaves `/opt/tenx-edge` owned by whichever local account holds uid 1001. The `--chown` here is still worth keeping afterwards: an image build should not depend on the ownership metadata inside a downloaded tarball.

`fwd/filebeat/debug/Dockerfile` is also missing the three startup fixes the non-debug variant has (`mkdir /var/log/tenx`, `TENX_LOG_APPENDER`, `filebeatLogsPath`). Separate concern, left alone here.
