### PR TITLE
docs(fwd): fluentd-10x has no :latest by choice, not by omission

### DIFF
--- a/.github/workflows/publish_10x_all_forwarders.yaml
+++ b/.github/workflows/publish_10x_all_forwarders.yaml
@@ -122,6 +122,11 @@ jobs:
       tenx_dist: Runtime
     secrets: inherit
 
+  # No publish_latest on Fluent Bit or Fluentd, deliberately, not by oversight.
+  # Both images are retired image-swap builds; the current model runs edge-10x as
+  # a sidecar. A mutable convenience tag on a retired build path only advertises
+  # a path we have moved off. Reasoning and the conditions for reversing it:
+  # fwd/fluentd/DEPRECATED.md.
   fluent-bit:
     if: ${{ inputs.publish_fluent_bit }}
     name: Fluent-Bit
@@ -148,6 +153,7 @@ jobs:
       tenx_dist: Runtime
     secrets: inherit
 
+  # See the note above fluent-bit: no publish_latest here either, deliberately.
   fluentd:
     if: ${{ inputs.publish_fluentd }}
     name: Fluentd

--- a/fwd/fluent-bit/DEPRECATED.md
+++ b/fwd/fluent-bit/DEPRECATED.md
@@ -9,3 +9,16 @@ values overlay), talking over loopback TCP.
 
 This Dockerfile is kept for **legacy rebuilds only**. See the current model:
 <https://doc.log10x.com/apps/receiver/deploy/>
+
+## No `:latest` tag, and that is deliberate
+
+`log10x/fluent-bit-10x` has no `:latest`, same as `log10x/fluentd-10x`, the other
+retired forwarder. `filebeat-10x` does, because Filebeat is the one forwarder
+still genuinely embedded. The full reasoning lives in
+[`fwd/fluentd/DEPRECATED.md`](../fluentd/DEPRECATED.md) and applies here
+unchanged.
+
+Short version: `:latest` is a mutable convenience pointer at the newest build of
+one image, and on a retired build path there is nothing to be convenient about.
+The tag is withheld by the `publish_latest` input on the `filebeat` job in
+`publish_10x_all_forwarders.yaml`, not by a missing job. Leave it off.

--- a/fwd/fluentd/DEPRECATED.md
+++ b/fwd/fluentd/DEPRECATED.md
@@ -9,3 +9,28 @@ overlay), talking over loopback TCP.
 
 This Dockerfile is kept for **legacy rebuilds only**. See the current model:
 <https://doc.log10x.com/apps/receiver/deploy/>
+
+## No `:latest` tag, and that is deliberate
+
+`log10x/fluentd-10x` has no `:latest`. Neither does `log10x/fluent-bit-10x`, the
+other retired forwarder. `filebeat-10x` does, because Filebeat is the one
+forwarder still genuinely embedded.
+
+`:latest` is a mutable convenience pointer at the newest build of one image. On a
+retired build path there is nothing to be convenient about: no docs tell anyone to
+pull this image, and `charts/fluentd/values.yaml` in `log-10x/fluent-helm-charts`
+defaults its tag to `{{ .Chart.AppVersion }}-{{ .Values.tenx.variant }}`, an
+explicit version, never `latest`. A `:latest` here would only advertise a path we
+have moved off, and it would move under anyone who found it.
+
+Mechanically the tag is withheld by one input, not by a missing job.
+`publish_10x_forwarder.yaml` carries `publish_latest_manifest` and every forwarder
+routes through that workflow, this one included. The job is gated on
+`publish_latest`, and `publish_10x_all_forwarders.yaml` sets that on the
+`filebeat` job alone, because the standard and debug builds would otherwise race
+for the same tag. So this is not the shape of the `lambda-10x` gap fixed in
+[#14](https://github.com/log-10x/docker-images/pull/14), where
+`publish_latest_manifest` was absent from the workflow file and had to be added.
+
+If Fluentd ever returns to an embedded build, set `publish_latest: true` on the
+`fluentd` job and on no other Fluentd job. Until then, leave it off.


### PR DESCRIPTION
## The question

`fluentd-10x` has no `:latest` while `pipeline-10x`, `edge-10x`, `compiler-10x`, `filebeat-10x` and `lambda-10x` all do. Is that the same shape of accident as the `lambda-10x` gap fixed in #14, where `publish_latest_manifest` was simply missing from the workflow file?

No. Different shape, and the difference is the whole answer.

## What the workflows say

`publish_10x_forwarder.yaml` carries `publish_latest_manifest` (added in #13) and every forwarder routes through that reusable workflow, Fluentd included:

```yaml
  publish_latest_manifest:
    name: Publish multiarch manifest for latest
    if: ${{ inputs.publish_latest }}
    needs:
      - prepare
      - publish_x86
      - publish_aarch64
      - smoke_launch
```

The job is present and reachable for Fluentd. What withholds the tag is the input. `publish_10x_all_forwarders.yaml` sets `publish_latest: true` on exactly one job:

```console
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/publish_10x_all_forwarders.yaml')); \
    print('jobs:', list(d['jobs'].keys())); \
    print('publish_latest set on:', [k for k,v in d['jobs'].items() if isinstance(v.get('with'),dict) and v['with'].get('publish_latest')])"
jobs: ['prepare', 'filebeat', 'filebeat-debug', 'fluent-bit', 'fluent-bit-debug', 'fluentd']
publish_latest set on: ['filebeat']
```

One job only, so the standard and debug builds do not race for the same tag. The comment above it already names the reason for picking Filebeat: the Fluent Bit and Fluentd image builds are retired.

By contrast, #14 had to **add** the job, because `publish_10x_lambda.yaml` did not have one at all. Fluentd's is there. Not the same defect.

## A correction to the premise

`fluentd-10x` is not the only image without a `:latest`. `fluent-bit-10x` has none either, 211 published tags and not one of them `latest`.

```console
$ docker manifest inspect log10x/fluentd-10x:latest
no such manifest: docker.io/log10x/fluentd-10x:latest

$ docker manifest inspect log10x/fluent-bit-10x:latest
no such manifest: docker.io/log10x/fluent-bit-10x:latest

$ docker manifest inspect log10x/filebeat-10x:latest
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
```

Both retired forwarders lack it, and Filebeat, the one still genuinely embedded, has it. Read that way the registry is already consistent. What was missing is the written rule, which is what this PR adds.

## Why not just add the tag

Nothing would consume it.

- Neither image is named in an install or deploy page. The only hits for `fluentd-10x` in `log-10x/mksite` sit inside a sample Kubernetes metadata JSON payload on `docs/run/transform/index.md`, not a pull instruction.
- `charts/fluentd/values.yaml` in `log-10x/fluent-helm-charts` defaults its tag to `{{ .Chart.AppVersion }}-{{ .Values.tenx.variant }}`, an explicit version, never `latest`. Same for the fluent-bit chart.
- Both directories already carry a `DEPRECATED.md` saying the image-swap model is retired and the current model runs `edge-10x` as a sidecar.

A mutable pointer on a retired build path would advertise a model we have moved off, and it would move under anyone who found it.

## What changes

Documentation only. No publish behavior changes, no tag moves.

- `fwd/fluentd/DEPRECATED.md`: the rule, the mechanism, and the exact condition for reversing it (`publish_latest: true` on the `fluentd` job and no other Fluentd job).
- `fwd/fluent-bit/DEPRECATED.md`: the short version, pointing at the fluentd file.
- `.github/workflows/publish_10x_all_forwarders.yaml`: a comment immediately above the `fluent-bit` and `fluentd` jobs, at the point of temptation, so the next person editing that file sees why `publish_latest` is absent before adding it.

## Constraints honored

- No existing `:latest` removed or repointed. Additions only: 44 insertions, 0 deletions across 3 files.
- No cross-image alias added.
- `fluentd-10x:latest` still does not exist and will not exist. This PR creates no tag, and merging it triggers no publish run.

## Verification

```console
$ docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest \
    .github/workflows/publish_10x_all_forwarders.yaml
actionlint container exit=0
```

No diagnostics. YAML parses, job graph unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
