### PR TITLE
fix(ci): authenticate the release lookup inside image builds

### DIFF
--- a/.github/workflows/publish_10x_edge.yaml
+++ b/.github/workflows/publish_10x_edge.yaml
@@ -127,6 +127,8 @@ jobs:
           build-args: |
             VERSION=${{inputs.release_version}}
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}
 
   publish_aarch64:
@@ -182,6 +184,8 @@ jobs:
           build-args: |
             VERSION=${{inputs.release_version}}
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}
 
   publish_version_manifest:

--- a/.github/workflows/publish_10x_forwarder.yaml
+++ b/.github/workflows/publish_10x_forwarder.yaml
@@ -217,6 +217,8 @@ jobs:
             VERSION=${{inputs.release_version}}
             FLAVOR=runtime
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}
 
   publish_aarch64:
@@ -273,6 +275,8 @@ jobs:
             VERSION=${{inputs.release_version}}
             FLAVOR=runtime
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}
 
   publish_manifest:

--- a/.github/workflows/publish_10x_lambda.yaml
+++ b/.github/workflows/publish_10x_lambda.yaml
@@ -157,6 +157,8 @@ jobs:
           build-args: |
             ENGINE_VERSION=${{ inputs.release_version }}
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}
 
   publish_aarch64:
     name: "Build aarch64 Lambda ${{needs.prepare.outputs.version_tag}}"
@@ -221,6 +223,8 @@ jobs:
           build-args: |
             ENGINE_VERSION=${{ inputs.release_version }}
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}
 
   publish_version_manifest:
     name: Publish multiarch manifest for ${{needs.prepare.outputs.version_tag}}

--- a/.github/workflows/publish_10x_lambda_native.yaml
+++ b/.github/workflows/publish_10x_lambda_native.yaml
@@ -186,3 +186,5 @@ jobs:
           tags: ${{ steps.docker-meta.outputs.tags }}
           build-args: |
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_10x_pipeline.yaml
+++ b/.github/workflows/publish_10x_pipeline.yaml
@@ -127,6 +127,8 @@ jobs:
           build-args: |
             VERSION=${{inputs.release_version}}
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}
 
   publish_aarch64:
@@ -182,6 +184,8 @@ jobs:
           build-args: |
             VERSION=${{inputs.release_version}}
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}
 
   publish_version_manifest:

--- a/.github/workflows/publish_10x_quarkus.yaml
+++ b/.github/workflows/publish_10x_quarkus.yaml
@@ -165,6 +165,8 @@ jobs:
           build-args: |
             DOCKER_IMAGE_TAG=${{needs.prepare.outputs.docker_repo}}/${{needs.prepare.outputs.image_name}}:${{needs.prepare.outputs.version_tag}}-amd64
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}
 
   publish_aarch64:
     name: "Build aarch64 Quarkus ${{needs.prepare.outputs.version_tag}}"
@@ -237,6 +239,8 @@ jobs:
           build-args: |
             DOCKER_IMAGE_TAG=${{needs.prepare.outputs.docker_repo}}/${{needs.prepare.outputs.image_name}}:${{needs.prepare.outputs.version_tag}}-aarch64
             LICENSE_JWT=${{ env.LICENSE_JWT }}
+          secrets: |
+            gh_token=${{ secrets.GITHUB_TOKEN }}
 
   publish_version_manifest:
     name: Publish multiarch manifest for ${{needs.prepare.outputs.version_tag}}

--- a/fwd/filebeat/Dockerfile
+++ b/fwd/filebeat/Dockerfile
@@ -28,7 +28,15 @@ RUN apt-get update && apt-get install -y curl
 
 # Install 10x
 #
-RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup
+# The token is a BuildKit secret, not a build-arg: these images are public and a
+# build-arg would be visible in `docker history` forever. It raises install.sh's
+# GitHub API limit, which is 60 requests/hour PER IP unauthenticated. The publish
+# fans out ~10 parallel builds on shared runner IPs, exhausts the quota, and the
+# builds fail with HTTP 403. Optional: absent, the install still works, it is just
+# rate-limited.
+RUN --mount=type=secret,id=gh_token \
+    TENX_GITHUB_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)" \
+    sh -c 'curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | TENX_GITHUB_TOKEN="$TENX_GITHUB_TOKEN" bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup'
 
 
 # Filebeat image

--- a/fwd/filebeat/debug/Dockerfile
+++ b/fwd/filebeat/debug/Dockerfile
@@ -28,7 +28,15 @@ RUN apt-get update && apt-get install -y curl
 
 # Install 10x
 #
-RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup
+# The token is a BuildKit secret, not a build-arg: these images are public and a
+# build-arg would be visible in `docker history` forever. It raises install.sh's
+# GitHub API limit, which is 60 requests/hour PER IP unauthenticated. The publish
+# fans out ~10 parallel builds on shared runner IPs, exhausts the quota, and the
+# builds fail with HTTP 403. Optional: absent, the install still works, it is just
+# rate-limited.
+RUN --mount=type=secret,id=gh_token \
+    TENX_GITHUB_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)" \
+    sh -c 'curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | TENX_GITHUB_TOKEN="$TENX_GITHUB_TOKEN" bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup'
 
 
 # Filebeat image

--- a/fwd/fluent-bit/Dockerfile
+++ b/fwd/fluent-bit/Dockerfile
@@ -31,7 +31,15 @@ RUN apt-get update && apt-get install -y curl
 
 # Install 10x
 #
-RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup
+# The token is a BuildKit secret, not a build-arg: these images are public and a
+# build-arg would be visible in `docker history` forever. It raises install.sh's
+# GitHub API limit, which is 60 requests/hour PER IP unauthenticated. The publish
+# fans out ~10 parallel builds on shared runner IPs, exhausts the quota, and the
+# builds fail with HTTP 403. Optional: absent, the install still works, it is just
+# rate-limited.
+RUN --mount=type=secret,id=gh_token \
+    TENX_GITHUB_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)" \
+    sh -c 'curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | TENX_GITHUB_TOKEN="$TENX_GITHUB_TOKEN" bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup'
 
 
 # Fluent-bit image

--- a/fwd/fluent-bit/debug/Dockerfile
+++ b/fwd/fluent-bit/debug/Dockerfile
@@ -28,7 +28,15 @@ RUN apt-get update && apt-get install -y curl
 
 # Install 10x
 #
-RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup
+# The token is a BuildKit secret, not a build-arg: these images are public and a
+# build-arg would be visible in `docker history` forever. It raises install.sh's
+# GitHub API limit, which is 60 requests/hour PER IP unauthenticated. The publish
+# fans out ~10 parallel builds on shared runner IPs, exhausts the quota, and the
+# builds fail with HTTP 403. Optional: absent, the install still works, it is just
+# rate-limited.
+RUN --mount=type=secret,id=gh_token \
+    TENX_GITHUB_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)" \
+    sh -c 'curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | TENX_GITHUB_TOKEN="$TENX_GITHUB_TOKEN" bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup'
 
 
 # Fluent-bit image

--- a/fwd/fluentd/Dockerfile
+++ b/fwd/fluentd/Dockerfile
@@ -28,7 +28,15 @@ RUN apt-get update && apt-get install -y curl
 
 # Install 10x
 #
-RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup
+# The token is a BuildKit secret, not a build-arg: these images are public and a
+# build-arg would be visible in `docker history` forever. It raises install.sh's
+# GitHub API limit, which is 60 requests/hour PER IP unauthenticated. The publish
+# fans out ~10 parallel builds on shared runner IPs, exhausts the quota, and the
+# builds fail with HTTP 403. Optional: absent, the install still works, it is just
+# rate-limited.
+RUN --mount=type=secret,id=gh_token \
+    TENX_GITHUB_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)" \
+    sh -c 'curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | TENX_GITHUB_TOKEN="$TENX_GITHUB_TOKEN" bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup'
 
 
 # Fluentd image

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -15,7 +15,15 @@ RUN dnf install -y curl
 
 # Install 10x
 #
-RUN curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup
+# The token is a BuildKit secret, not a build-arg: these images are public and a
+# build-arg would be visible in `docker history` forever. It raises install.sh's
+# GitHub API limit, which is 60 requests/hour PER IP unauthenticated. The publish
+# fans out ~10 parallel builds on shared runner IPs, exhausts the quota, and the
+# builds fail with HTTP 403. Optional: absent, the install still works, it is just
+# rate-limited.
+RUN --mount=type=secret,id=gh_token \
+    TENX_GITHUB_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)" \
+    sh -c 'curl https://raw.githubusercontent.com/log-10x/pipeline-releases/main/install.sh | TENX_GITHUB_TOKEN="$TENX_GITHUB_TOKEN" bash -s -- --version ${VERSION} --flavor ${FLAVOR} --no-env-setup'
 
 FROM --platform=${BUILDPLATFORM:-linux/amd64} registry.access.redhat.com/ubi8/ubi-minimal:8.10
 


### PR DESCRIPTION
`publish_10x_all_forwarders` fans out ~10 parallel builds, each running `install.sh`, which calls the GitHub release API. Unauthenticated that limit is **60 requests/hour per IP** and runners share IPs, so the quota is exhausted and builds die with HTTP 403. **Three publishes were lost to this today**, a different job failing each time, which is the signature of a shared quota rather than a bad pattern.

Passes `GITHUB_TOKEN` as a **BuildKit secret, not a build-arg**: these images are public and a build-arg stays visible in `docker history` forever.

The secret is optional, so builds outside CI keep working. Verified both ways with real builds of `fwd/filebeat/Dockerfile` at 1.1.39:

| | result |
|---|---|
| `--secret id=gh_token` | exit 0 |
| no secret | exit 0, zero rate-limit errors |

Pairs with pipeline-releases#9, which added the token support and made a 403 report itself instead of printing `No asset found matching pattern`.