### PR TITLE
docs: evaluation license replaces the limited-license framing

### DIFF
--- a/edge/README.md
+++ b/edge/README.md
@@ -9,7 +9,7 @@ Run the latest release with:
 docker run ghcr.io/log-10x/edge-10x:latest
 ```
 
-The image ships with a built-in limited license. For the full engine, download your own from [console.log10x.com](https://console.log10x.com) and pass it as `-e TENX_LICENSE_KEY="$(cat license.jwt)"`. See [log10x.com/pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=inline).
+No license is needed to evaluate: the engine runs on its built-in 30-day evaluation license (10 nodes, airgapped). For a production license, see [licensing](https://doc.log10x.com/manage/license/) and pass it as `-e TENX_LICENSE_KEY="$(cat license.jwt)"`. See [log10x.com/pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=inline).
 
 ## Under the hood
 

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -27,7 +27,7 @@ Entry point: `com.log10x.ext.lambda.RetrieverHandler::handleRequest`.
 
 ## License
 
-The image ships with a built-in limited license. For the full engine, set the Lambda function's `TENX_LICENSE_KEY` env var to a JWT downloaded from [console.log10x.com](https://console.log10x.com) — the `terraform-aws-tenx-retriever-lambda` module exposes it as an input variable. See [log10x.com/pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=inline).
+No license is needed to evaluate: the engine runs on its built-in 30-day evaluation license (10 nodes, airgapped). For a production license, set the Lambda function's `TENX_LICENSE_KEY` env var to a JWT (see [licensing](https://doc.log10x.com/manage/license/)) — the `terraform-aws-tenx-retriever-lambda` module exposes it as an input variable. See [log10x.com/pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=inline).
 
 ## Manual build (only for debugging the Dockerfile)
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -9,7 +9,7 @@ Run the latest release with:
 docker run ghcr.io/log-10x/log10x-pipeline:latest
 ```
 
-The image ships with a built-in limited license. For the full engine, download your own from [console.log10x.com](https://console.log10x.com) and pass it as `-e TENX_LICENSE_KEY="$(cat license.jwt)"`. See [log10x.com/pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=inline).
+No license is needed to evaluate: the engine runs on its built-in 30-day evaluation license (10 nodes, airgapped). For a production license, see [licensing](https://doc.log10x.com/manage/license/) and pass it as `-e TENX_LICENSE_KEY="$(cat license.jwt)"`. See [log10x.com/pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=docker-images&utm_content=inline).
 
 ## Under the hood
 


### PR DESCRIPTION
Companion to engine 1.1.73. Follow-up for the next image publish: drop the baked limited license.jwt entirely; the engine's built-in evaluation license supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)