### PR TITLE
feat: drop the baked limited license from every image

### DIFF
--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -45,7 +45,6 @@ ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules
 ENV TENX_CONFIG=/etc/tenx/config
 ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
-ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 
 # Set 10x logger to console.
 #

--- a/fwd/filebeat/Dockerfile
+++ b/fwd/filebeat/Dockerfile
@@ -64,7 +64,6 @@ ENV TENX_HOME=/opt/tenx-edge
 ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules
 ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
-ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 #
 # Setting up the path to config files
 # This can be overriden by deployment envs like k8s, when creating user config

--- a/fwd/filebeat/debug/Dockerfile
+++ b/fwd/filebeat/debug/Dockerfile
@@ -64,7 +64,6 @@ ENV TENX_HOME=/opt/tenx-edge
 ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules
 ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
-ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 #
 # Setting up the path to config files
 # This can be overriden by deployment envs like k8s, when creating user config

--- a/fwd/fluent-bit/Dockerfile
+++ b/fwd/fluent-bit/Dockerfile
@@ -68,7 +68,6 @@ ENV TENX_HOME=/opt/tenx-edge
 ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules
 ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
-ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 #
 # Setting up the path to config files
 # This can be overriden by deployment envs like k8s, when creating user config

--- a/fwd/fluent-bit/debug/Dockerfile
+++ b/fwd/fluent-bit/debug/Dockerfile
@@ -65,7 +65,6 @@ ENV TENX_HOME=/opt/tenx-edge
 ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules
 ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
-ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 #
 # Setting up the path to config files
 # This can be overriden by deployment envs like k8s, when creating user config

--- a/fwd/fluentd/Dockerfile
+++ b/fwd/fluentd/Dockerfile
@@ -67,7 +67,6 @@ ENV TENX_HOME=/opt/tenx-edge
 ENV TENX_BIN=/opt/tenx-edge/bin/tenx-edge
 ENV TENX_MODULES=/opt/tenx-edge/lib/app/modules
 ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
-ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 #
 # Setting up the path to config files
 # This can be overriden by deployment envs like k8s, when creating user config

--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -55,7 +55,6 @@ ENV TENX_HOME=/var/task/tenx-home \
     TENX_MODULES=/var/task/tenx-home/modules \
     TENX_SYMBOLS_PATH=/var/task/tenx-home/config/data/shared/symbols \
     TENX_LOG_APPENDER=tenxConsoleAppender \
-    TENX_LOG_PATH=/tmp/ \
-    TENX_LICENSE_KEY=${LICENSE_JWT}
+    TENX_LOG_PATH=/tmp/
 
 CMD [ "com.log10x.ext.lambda.RetrieverHandler::handleRequest" ]

--- a/lambda/Dockerfile.native
+++ b/lambda/Dockerfile.native
@@ -67,8 +67,7 @@ ENV TENX_HOME=/var/task/tenx-home \
     TENX_MODULES=/var/task/tenx-home/modules \
     TENX_SYMBOLS_PATH=/var/task/tenx-home/config/data/shared/symbols \
     TENX_LOG_APPENDER=tenxConsoleAppender \
-    TENX_LOG_PATH=/tmp/ \
-    TENX_LICENSE_KEY=${LICENSE_JWT}
+    TENX_LOG_PATH=/tmp/
 
 # The handler string the managed runtime needed has no meaning here: the role is
 # selected by the ROLE env var, which RetrieverHandler reads directly. CMD is

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -80,7 +80,6 @@ ENV TENX_BIN=/opt/tenx-${PACKAGE_ID}/bin/tenx-${PACKAGE_ID}
 ENV TENX_MODULES=/opt/tenx-${PACKAGE_ID}/lib/app/modules
 ENV TENX_CONFIG=/etc/tenx/config
 ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
-ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 
 # Set 10x logger to console.
 #

--- a/quarkus/Dockerfile
+++ b/quarkus/Dockerfile
@@ -149,7 +149,6 @@ ENV TENX_MODULES=/etc/tenx/modules
 ENV TENX_CONFIG=/etc/tenx/config
 ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
 ENV TENX_DOCKER_IMAGE=${DOCKER_IMAGE_TAG}
-ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 
 ENV TENX_LOG_APPENDER=tenxConsoleAppender
 ENV JAVA_OPTS_APPEND="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Djdk.httpclient.allowRestrictedHeaders=host -Dfile.encoding=UTF-8"

--- a/quarkus/Dockerfile.debug
+++ b/quarkus/Dockerfile.debug
@@ -152,7 +152,6 @@ ENV TENX_MODULES=/etc/tenx/modules
 ENV TENX_CONFIG=/etc/tenx/config
 ENV TENX_SYMBOLS_PATH=/etc/tenx/symbols
 ENV TENX_DOCKER_IMAGE=${DOCKER_IMAGE_TAG}
-ENV TENX_LICENSE_KEY=${LICENSE_JWT}
 
 ENV TENX_LOG_APPENDER=tenxConsoleAppender
 ENV JAVA_OPTS_APPEND="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Djdk.httpclient.allowRestrictedHeaders=host -Dfile.encoding=UTF-8"


### PR DESCRIPTION
The baked key predates the evaluation license and now makes images strictly worse than an unlicensed engine. 11 Dockerfiles, deletions only. Republish follows merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)