### PR TITLE
fwd: drop dead LICENSE_JWT plumbing; forwarder images await republish

### DIFF
--- a/.github/workflows/publish_10x_forwarder.yaml
+++ b/.github/workflows/publish_10x_forwarder.yaml
@@ -175,9 +175,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
-
       - name: Login to GHCR
         if: ${{ inputs.docker_hub == 'GHCR' || inputs.docker_hub == 'All' }}
         uses: docker/login-action@v4
@@ -216,7 +213,6 @@ jobs:
           build-args: |
             VERSION=${{inputs.release_version}}
             FLAVOR=runtime
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}
@@ -232,9 +228,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: main
-
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       - name: Login to GHCR
         if: ${{ inputs.docker_hub == 'GHCR' || inputs.docker_hub == 'All' }}
@@ -274,7 +267,6 @@ jobs:
           build-args: |
             VERSION=${{inputs.release_version}}
             FLAVOR=runtime
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}

--- a/fwd/filebeat/Dockerfile
+++ b/fwd/filebeat/Dockerfile
@@ -53,7 +53,6 @@ LABEL org.opencontainers.image.source="https://github.com/log-10x/docker-images"
 LABEL com.log10x.license.required="true"
 LABEL com.log10x.license.url="https://log10x.com/pricing"
 
-ARG LICENSE_JWT
 
 # Manually setting up 10x environment variables
 #

--- a/fwd/filebeat/debug/Dockerfile
+++ b/fwd/filebeat/debug/Dockerfile
@@ -53,7 +53,6 @@ LABEL org.opencontainers.image.source="https://github.com/log-10x/docker-images"
 LABEL com.log10x.license.required="true"
 LABEL com.log10x.license.url="https://log10x.com/pricing"
 
-ARG LICENSE_JWT
 
 # Manually setting up 10x environment variables
 #

--- a/fwd/fluent-bit/Dockerfile
+++ b/fwd/fluent-bit/Dockerfile
@@ -57,7 +57,6 @@ LABEL org.opencontainers.image.source="https://github.com/log-10x/docker-images"
 LABEL com.log10x.license.required="true"
 LABEL com.log10x.license.url="https://log10x.com/pricing"
 
-ARG LICENSE_JWT
 
 # Manually setting up 10x environment variables
 #

--- a/fwd/fluent-bit/debug/Dockerfile
+++ b/fwd/fluent-bit/debug/Dockerfile
@@ -54,7 +54,6 @@ LABEL org.opencontainers.image.source="https://github.com/log-10x/docker-images"
 LABEL com.log10x.license.required="true"
 LABEL com.log10x.license.url="https://log10x.com/pricing"
 
-ARG LICENSE_JWT
 
 # Manually setting up 10x environment variables
 #

--- a/fwd/fluentd/Dockerfile
+++ b/fwd/fluentd/Dockerfile
@@ -56,7 +56,6 @@ LABEL com.log10x.license.url="https://log10x.com/pricing"
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ARG LICENSE_JWT
 
 # Manually setting up 10x environment variables
 #


### PR DESCRIPTION
Follow-up to #21: forwarder Dockerfiles kept an unused `ARG LICENSE_JWT` and the publish workflow still read `license.jwt` into a build-arg nothing consumes. Both gone.

The live ghcr forwarder images still bake the limited license because publish_10x_forwarder last ran 2026-07-30 (pre-#21). Republish follows this merge, after the 1.1.74 config tarball lands so the images also stop phoning home by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)