### PR TITLE
images: README stops promising a licence the images do not carry

### DIFF
--- a/.github/workflows/publish_10x_edge.yaml
+++ b/.github/workflows/publish_10x_edge.yaml
@@ -86,8 +86,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       - name: Login to GHCR
         if: ${{ inputs.docker_hub == 'GHCR' || inputs.docker_hub == 'All' }}
@@ -126,7 +124,6 @@ jobs:
           provenance: false
           build-args: |
             VERSION=${{inputs.release_version}}
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}
@@ -143,8 +140,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       - name: Login to GHCR
         if: ${{ inputs.docker_hub == 'GHCR' || inputs.docker_hub == 'All' }}
@@ -183,7 +178,6 @@ jobs:
           provenance: false
           build-args: |
             VERSION=${{inputs.release_version}}
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}

--- a/.github/workflows/publish_10x_lambda.yaml
+++ b/.github/workflows/publish_10x_lambda.yaml
@@ -101,8 +101,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       # gh CLI requires a token, but built-in GITHUB_TOKEN works for public repos
       - name: Prepare release artifacts
@@ -156,7 +154,6 @@ jobs:
           tags: ${{ steps.docker-meta.outputs.tags }}
           build-args: |
             ENGINE_VERSION=${{ inputs.release_version }}
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}
 
@@ -172,8 +169,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       - name: Prepare release artifacts
         env:
@@ -222,7 +217,6 @@ jobs:
           tags: ${{ steps.docker-meta.outputs.tags }}
           build-args: |
             ENGINE_VERSION=${{ inputs.release_version }}
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish_10x_lambda_native.yaml
+++ b/.github/workflows/publish_10x_lambda_native.yaml
@@ -104,8 +104,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       # gh CLI requires a token, but built-in GITHUB_TOKEN works for public repos
       - name: Prepare release artifacts
@@ -185,6 +183,5 @@ jobs:
           sbom: false
           tags: ${{ steps.docker-meta.outputs.tags }}
           build-args: |
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_10x_pipeline.yaml
+++ b/.github/workflows/publish_10x_pipeline.yaml
@@ -86,8 +86,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       - name: Login to GHCR
         if: ${{ inputs.docker_hub == 'GHCR' || inputs.docker_hub == 'All' }}
@@ -126,7 +124,6 @@ jobs:
           provenance: false
           build-args: |
             VERSION=${{inputs.release_version}}
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}
@@ -143,8 +140,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       - name: Login to GHCR
         if: ${{ inputs.docker_hub == 'GHCR' || inputs.docker_hub == 'All' }}
@@ -183,7 +178,6 @@ jobs:
           provenance: false
           build-args: |
             VERSION=${{inputs.release_version}}
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-meta.outputs.tags }}

--- a/.github/workflows/publish_10x_quarkus.yaml
+++ b/.github/workflows/publish_10x_quarkus.yaml
@@ -106,8 +106,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       # gh CLI requires a token, but built-in GITHUB_TOKEN works for public repos
       - name: Prepare release artifacts
@@ -164,7 +162,6 @@ jobs:
           tags: ${{ steps.docker-meta.outputs.tags }}
           build-args: |
             DOCKER_IMAGE_TAG=${{needs.prepare.outputs.docker_repo}}/${{needs.prepare.outputs.image_name}}:${{needs.prepare.outputs.version_tag}}-amd64
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}
 
@@ -180,8 +177,6 @@ jobs:
         with:
           path: main
 
-      - name: Load embedded limited license JWT
-        run: echo "LICENSE_JWT=$(cat ./main/license.jwt)" >> "$GITHUB_ENV"
 
       # gh CLI requires a token, but built-in GITHUB_TOKEN works for public repos
       - name: Prepare release artifacts
@@ -238,7 +233,6 @@ jobs:
           tags: ${{ steps.docker-meta.outputs.tags }}
           build-args: |
             DOCKER_IMAGE_TAG=${{needs.prepare.outputs.docker_repo}}/${{needs.prepare.outputs.image_name}}:${{needs.prepare.outputs.version_tag}}-aarch64
-            LICENSE_JWT=${{ env.LICENSE_JWT }}
           secrets: |
             gh_token=${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ these images require a license to use.**
 | Build scripts | Running Log10x containers |
 | Container configuration | Log10x engine features |
 
-Every image ships with a built-in **limited** license so it runs out of the box. To unlock the full engine, pass your own `license.jwt` at run time:
+Images carry no license. Started without one, the engine runs the built-in
+evaluation license: the full product, 30 days from process start, 10 nodes,
+air-gapped, with no outbound call. Pass your own token to license a
+deployment:
 
 ```console
 -e TENX_LICENSE_KEY="$(cat license.jwt)"

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -31,7 +31,6 @@ LABEL com.log10x.license.url="https://log10x.com/pricing"
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
-ARG LICENSE_JWT
 
 # Make sure path for log file exists and is accessible to all users.
 # This allows changing TENX_LOG_APPENDER to tenxFileAppender if desired

--- a/lambda/Dockerfile
+++ b/lambda/Dockerfile
@@ -26,7 +26,6 @@
 
 ARG ENGINE_VERSION
 ARG ENGINE_IMAGE=log10x/quarkus-10x:${ENGINE_VERSION}
-ARG LICENSE_JWT
 
 # Stage 1: pull tenx-home (config / modules / symbols) from the matching
 # quarkus image so the Lambda image always tracks the engine release —

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -44,7 +44,6 @@ ARG BUILDPLATFORM
 # with the flavor rename -- see pipeline-releases/FLAVORS.md. Change these two
 # only together.
 ARG PACKAGE_ID="cloud"
-ARG LICENSE_JWT
 
 # Install binutils (strings) + file (executable scanner), needed for 10x 'compile'
 # Install shadow-utils, needed for useradd

--- a/quarkus/Dockerfile
+++ b/quarkus/Dockerfile
@@ -94,7 +94,6 @@ LABEL com.log10x.license.url="https://log10x.com/pricing"
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG DOCKER_IMAGE_TAG=unknown
-ARG LICENSE_JWT
 
 ENV LANGUAGE='en_US:en'
 


### PR DESCRIPTION
`README.md` said "Every image ships with a built-in **limited** license so it runs out of the box". False since #21 dropped the bake, and this is the first file a reader opens on the public image repo. It now describes what actually happens: no licence in the image, so an unconfigured start takes the built-in evaluation licence (full product, 30 days, 10 nodes, air-gapped, no outbound call).

Dead plumbing removed with it: `ARG LICENSE_JWT` in the lambda, edge, quarkus and pipeline Dockerfiles, which no `ENV` consumes, and the five publish workflows still reading `license.jwt` into the build environment to pass into that unused arg. A real licence token no longer travels through CI for no reason.

Found by a verification pass reading the docs against source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)